### PR TITLE
Dummy data for recipe entries

### DIFF
--- a/front-end/app/resources/data/recipe-data.json
+++ b/front-end/app/resources/data/recipe-data.json
@@ -1,0 +1,68 @@
+{
+    "recipes": [
+        {
+            "name": "chicken taco",
+            "ingredients": [
+                "extra-virgin olive oil",
+                "chicken breasts",
+                "corn tortilla",
+                "kosher salt",
+                "black pepper",
+                "chilli powder",
+                "ground cumin",
+                "paprika",
+                "cayene",
+                "sour cream",
+                "salsa",
+                "shredded montgomery cheese"
+            ],
+            "time to cook": 30
+        },
+        {
+            "name": "vegetable stir fry",
+            "ingredients": [
+                "olive oil",
+                "red bell pepper",
+                "yellow bell peppers",
+                "sugar snap peas",
+                "carrots",
+                "mushrooms",
+                "broccoli",
+                "baby corn",
+                "water chestnuts",
+                "soy sauce",
+                "garlic cloves (minced)",
+                "brown sugar",
+                "sesame oil",
+                "chicken broth",
+                "cornstarch",
+                "green onions",
+                "sesame seeds"
+            ],
+            "time to cook": 15
+        },
+        {
+            "name": "chicken stir fry",
+            "ingredients": [
+                "chicken breasts",
+                "salt",
+                "pepper",
+                "olive oil",
+                "broccoli",
+                "yellow bell peppers",
+                "red bell pepper",
+                "baby carrots",
+                "minced ginger",
+                "minced garlic cloves",
+                "corn starch",
+                "cold water",
+                "chicken broth",
+                "soy sauce",
+                "honey",
+                "toasted sesame oil",
+                "crushed red pepper flakes"
+            ],
+            "time to cook": 18
+        }
+    ]
+}


### PR DESCRIPTION
In this pull request, I created three recipe entries as dummy data to populate the recipe list entries component that we will create. 

The three recipes are chicken tacos, vegetable stir fry, and chicken stir fry. I created two recipe entries that were the same kind of food and one that was different.

The data is formatted as json and each recipe contains the following fields:
- recipe name
- ingredients
- time to cook