### PR TITLE
Home page recipe entries list

### DIFF
--- a/front-end/app/components/RecipeEntry.js
+++ b/front-end/app/components/RecipeEntry.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import "./../resources/styles/RecipeEntry.css";
+
+function RecipeEntry() {
+    return (
+        <div className="recipe-entry">
+            Recipe
+        </div>
+    );
+}
+
+export default RecipeEntry;

--- a/front-end/app/components/RecipeEntryList.js
+++ b/front-end/app/components/RecipeEntryList.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import RecipeEntry from './RecipeEntry';
+import Grid from "@mui/material/Grid";
+import "./../resources/styles/RecipeEntryList.css";
+
+function RecipeEntryList() {
+    return (
+        <Grid container alignItems="center">
+            <Grid container justifyContent="center" spacing={2} className="row">
+                <Grid item>
+                    <RecipeEntry />
+                </Grid>
+                <Grid item>
+                    <RecipeEntry />
+                </Grid>
+            </Grid>
+            <Grid container justifyContent="center" spacing={2} className="row">
+                <Grid item>
+                    <RecipeEntry />
+                </Grid>
+                <Grid item>
+                    <RecipeEntry />
+                </Grid>
+            </Grid>
+            <Grid container justifyContent="center" spacing={2} className="row">
+                <Grid item>
+                    <RecipeEntry />
+                </Grid>
+                <Grid item>
+                    <RecipeEntry />
+                </Grid>
+            </Grid>
+        </Grid>
+    );
+}
+
+export default RecipeEntryList;

--- a/front-end/app/components/pages/Home.js
+++ b/front-end/app/components/pages/Home.js
@@ -1,11 +1,15 @@
 import React from "react";
 import Header from "../Header";
+import RecipeEntryList from "../RecipeEntryList";
 
 function Home() {
     return(
         <div>
             <p>HOME PAGE</p>
             <Header />
+            <RecipeEntryList />
         </div>
     );
-} export default Home;
+}
+
+export default Home;

--- a/front-end/app/resources/data/recipe-data.json
+++ b/front-end/app/resources/data/recipe-data.json
@@ -1,0 +1,68 @@
+{
+    "recipes": [
+        {
+            "name": "chicken taco",
+            "ingredients": [
+                "extra-virgin olive oil",
+                "chicken breasts",
+                "corn tortilla",
+                "kosher salt",
+                "black pepper",
+                "chilli powder",
+                "ground cumin",
+                "paprika",
+                "cayene",
+                "sour cream",
+                "salsa",
+                "shredded montgomery cheese"
+            ],
+            "time to cook": 30
+        },
+        {
+            "name": "vegetable stir fry",
+            "ingredients": [
+                "olive oil",
+                "red bell pepper",
+                "yellow bell peppers",
+                "sugar snap peas",
+                "carrots",
+                "mushrooms",
+                "broccoli",
+                "baby corn",
+                "water chestnuts",
+                "soy sauce",
+                "garlic cloves (minced)",
+                "brown sugar",
+                "sesame oil",
+                "chicken broth",
+                "cornstarch",
+                "green onions",
+                "sesame seeds"
+            ],
+            "time to cook": 15
+        },
+        {
+            "name": "chicken stir fry",
+            "ingredients": [
+                "chicken breasts",
+                "salt",
+                "pepper",
+                "olive oil",
+                "broccoli",
+                "yellow bell peppers",
+                "red bell pepper",
+                "baby carrots",
+                "minced ginger",
+                "minced garlic cloves",
+                "corn starch",
+                "cold water",
+                "chicken broth",
+                "soy sauce",
+                "honey",
+                "toasted sesame oil",
+                "crushed red pepper flakes"
+            ],
+            "time to cook": 18
+        }
+    ]
+}

--- a/front-end/app/resources/styles/RecipeEntry.css
+++ b/front-end/app/resources/styles/RecipeEntry.css
@@ -1,0 +1,11 @@
+.recipe-entry {
+    background-color: #ccc;
+    width: 250px;
+    height: 200px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 18px;
+    font-weight: bold;
+    border-radius: 10px;
+  }

--- a/front-end/app/resources/styles/RecipeEntryList.css
+++ b/front-end/app/resources/styles/RecipeEntryList.css
@@ -1,0 +1,5 @@
+.row {
+    padding-top: 20px;
+    padding-right: 10px;
+    padding-left: 10px;
+}


### PR DESCRIPTION
In this pull request, I created blank recipe entry components that populate the home page as a grid.

In the future, we can populate the recipe entries but for now they are blank. 

The following is an image of how the grid of recipe entries looks on the home page:
![image](https://user-images.githubusercontent.com/69612398/218570210-4c199d26-1a69-4291-ad87-8fe881ec6311.png)
