### PR TITLE
Added API routes

### DIFF
--- a/api_routes.md
+++ b/api_routes.md
@@ -269,6 +269,7 @@ This route is for creating a new user into the data access layer. This user won'
 POST /create/user HTTP/1.1
 ...
 Content-type: application/json
+Accept: application/json
 ...
 ```
 ### Body details
@@ -476,7 +477,7 @@ A 200 status code will be returned if the recipe was successfully bookmarked.
 
 A 404 status code will be returned if the username or recipe name don't correspond to an existing user or recipe, respectively.
 
-A 400 (Bad request) will be returned if any of the fields are null or missing.
+A 400 (Bad request) will be returned if any of the fields are null or missing, or if the user already has the recipe saved.
 
 A 401 (Unauthorized) status code will be returned if the JWT token from `encryptedJwtToken` is invalid.
 ### Example response

--- a/api_routes.md
+++ b/api_routes.md
@@ -549,7 +549,7 @@ Accept: application/json
 ...
 ```
 ### Body details
-The body will be JSON containing the username of the user, the recipe whose ingredients they want to add to their shopping list, and if they only want to add the recipe's ingredients that they're currently missing.
+The body will be JSON containing the username of the user, the recipe whose ingredients they want to add to their shopping list, and if they only want to add the recipe's ingredients that they're currently missing. If `addOnlyMissingIngredients` is missing or null, it will default to `false`.
 ### Example body
 ```
 {
@@ -564,7 +564,7 @@ A 200 status code will be returned if the recipe's ingredients are successfully 
 
 A 404 status code will be returned if the username or recipe name doesn't correspond to an existing user or recipe, respectively.
 
-A 400 (Bad request) status code will be returned if any of the fields are missing or null.
+A 400 (Bad request) status code will be returned if any of the fields (except `addOnlyMissingIngredients`) are missing or null.
 
 A 401 (Unauthorized) status code will be returned if the JWT token from encryptedJwtToken is invalid.
 ### Example response

--- a/api_routes.md
+++ b/api_routes.md
@@ -207,7 +207,7 @@ The body will be JSON containing the recipe details, as well as the name of the 
 }
 ```
 ### Response
-A 201 (Created) status code will be returned if the recipe was successfully created. The response will contain the unique recipe name assigned to the recipe (`assignedName`). If any of the tags don't correspond to an existing tag name, then new tags will be created for them.
+A 201 (Created) status code will be returned if the recipe was successfully created. The response will contain the unique recipe name assigned to the recipe (`assignedName`). If any of the tags don't correspond to an existing tag name, then new tags will be created for them, and they will be in the field `createdTags`.
 
 A 400 (Bad request) status code will be returned if the recipe data is invalid. Recipe data is invalid if any of the following are true:
 * The `presentationName`, `authorUsername`, `encryptedJwtToken`, or `recipe` is missing or null.
@@ -215,14 +215,14 @@ A 400 (Bad request) status code will be returned if the recipe data is invalid. 
 * Any of the `directions` elements are null.
 * Any of the `tags` elements are null.
 * Any of the `requiredIngredients` keys or values are null.
-* The `authorUsername` doesn't correspond to an existing user.
 
-A 404 (Not found) status code will be returned if any of the recipe's `requiredIngredients` keys don't correspond to existing ingredients.
+A 404 (Not found) status code will be returned if any of the following are true:
+* The `authorUsername` doesn't correspond to an existing user.
+* Any of the recipe's `requiredIngredients` keys don't correspond to existing ingredients.
 
 A 401 (Unauthorized) status code will be returned if the JWT token from `encryptedJwtToken` is invalid (not yet implemented).
 
 Note: the fields `directions`, `tags`, and `requiredIngredients` can be null themselves; they just can't have null elements.
-The response will also contain a message with some details about what happened when handling the request (i.e. what error occurred if any, etc.)
 ### Example response
 ```
 HTTP/1.1 201 Created
@@ -232,7 +232,8 @@ Content-type: application/json
 
 {
     "message": "Recipe creation successful: the recipe was assigned a new unique (non-presentation) name",
-    "assignedName": "tasty-cheese-omelette2"
+    "assignedName": "tasty-cheese-omelette2",
+    "createdTags": []
 }
 ```
 
@@ -255,7 +256,9 @@ The body will be JSON containing the username of the user, and their email addre
 }
 ```
 ### Response
-A 201 (Created) status code will be returned if the user is successfully created. A 400 (Bad request) status code will be returned if the username is null, missing, or already taken.
+A 201 (Created) status code will be returned if the user is successfully created.
+
+A 400 (Bad request) status code will be returned if the username is null, missing, or already taken.
 ### Example response
 ```
 HTTP/1.1 201 Created

--- a/api_routes.md
+++ b/api_routes.md
@@ -1,21 +1,26 @@
 # API Routes for front-end and back-end communication
-## Search for recipe
-This route is for searching for recipes (that aren't known yet to the user) based on given search terms.
+### General notes
+* Access these API routes by connecting to `localhost:4567` while running the backend.
+* Each request body and response body is in JSON.
+* Each request's response body will contain a `"message"` field with some details about what happened when handling the request (i.e. what error occurred if any, etc.)
+## Get recipe
+This route is for getting the information of an existing recipe.
 ### Header
 ```
-GET /search/recipes HTTP/1.1
+GET /recipes/:recipe HTTP/1.1
 ...
 Accept: application/json
 ...
 ```
-### Query parameters
-`terms`: what the search terms are. Each search term is separated by a "+".
-### Example request
-`/search/recipes?terms=cheese+omelette` will perform a search with the terms "cheese" and "omelette".
+### Header details
+":recipe" is the recipe's unique (non-presentation) name. For example, if the recipe was "tasty-cheese-omelette2", then the URI would be `/recipes/tasty-cheese-omelette2`.
 ### Response
-A 200 status code will be returned if the search was successful, even if no recipes matched with the search terms. A 400 status code will be returned if no search terms are given (ex. just `search/recipes`). The body will be in JSON.  
-The response will also contain a message with some details about what happened when handling the request (i.e. what error occurred if any, etc.)
-### Example responses
+A 200 status code will be returned if the recipe was successfully retrieved.
+
+A 404 status code will be returned if the recipe name doesn't correspond to an existing recipe.
+
+Also, note that the users, ingredients, and tags are just their names, so additional requests will need to be made to get information on each of them.
+### Example response
 ```
 HTTP/1.1 200 OK
 ...
@@ -23,69 +28,9 @@ Content-type: application/json
 ...
 
 {
-    "message": "Search successful: recipes that matched were found",
-    "matches": [
-        {
-            "name": "tasty_cheese_omelette2",
-            "presentationName": "Tasty Cheese Omelette",
-            "authorUsername": "OmeletteLover2000"
-            "prepTime": 5,
-            "cookTime": 5,
-            "imageUri": "image/resource/here.png",
-            "numServings": 1,
-            "avgRating": 4.5,
-            "numRatings": 20,
-            "directions": [
-                "Crack eggs into bowl",
-                "Beat eggs",
-                "Start stove with temperature on medium",
-                ...
-            ],
-            "tags": [
-                "breakfast",
-                "quick",
-                ...
-            ],
-            "requiredIngredients": {
-                "egg": 2,
-                "cheese": 0.75,
-                ...
-            }
-        },
-        ...
-    ]
-}
-```
-```
-HTTP/1.1 200 OK
-...
-Content-type: application/json
-...
-
-{
-    "message": "Search successful: but no matching recipes were found",
-    "recipes": []
-}
-```
-Note that `prepTime` and `cookTime` are in minutes.
-## Create recipe
-This route is for creating new recipes to be saved into the data access layer.
-### Header
-```
-POST /recipes/create HTTP/1.1
-...
-Content-type: application/json
-Accept: application/json
-...
-```
-### Body details
-The body will be JSON containing the recipe details, as well as the name of the user that created the recipe (`authorUsername`). Only the `authorUsername` and `presentationName` are required, but if other fields are left out, then the recipe will have fewer details. If `name` is excluded or null, then a unique recipe name will be assigned to the recipe.
-### Example body
-```
-{
-    "encryptedJwtToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    "message": "Recipe retrieval successful",
     "recipe": {
-        "name": "tasty_cheese_omelette2",
+        "name": "tasty-cheese-omelette2",
         "presentationName": "Tasty Cheese Omelette",
         "authorUsername": "OmeletteLover2000"
         "prepTime": 5,
@@ -107,23 +52,176 @@ The body will be JSON containing the recipe details, as well as the name of the 
         ],
         "requiredIngredients": {
             "egg": 2,
-            "cheese": 0.75,
+            "cheddar-cheese": 0.75,
+            ...
+    }
+}
+```
+## Get user
+This route is for getting the information of an existing user. 
+### Header
+```
+GET /users/:user HTTP/1.1
+...
+Accept: application/json
+...
+```
+### Header details
+":user" is the user's username. For example, if the username was "OmeletteLover2000", then the URI would be `/users/OmeletteLover2000`.
+### Response
+A 200 status code will be returned if the user was successfully retrieved.
+
+A 404 status code will be returned if the username doesn't correspond to an existing user.
+
+Also, note that the recipes and ingredients are just their names, so additional requests will need to be made to get information on each of them.
+### Example response
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "User retrieval successful",
+    "user": {
+        "username": "OmeletteLover2000",
+        "emailAddress": "ExampleEmail@aol.com",
+        "authoredRecipes": ["tasty-cheese-omelette2", "egg-surprise", "egg-in-baskets", ...],
+        "savedRecipes": ["lovely-omelette", "zesty-omelette", ...],
+        "ratedRecipes": {
+            "lovely-omelette": 5.0,
+            "over-easy-eggs": 1.0,
+            ...
+        },
+        "ownedIngredients": ["eggs", "cheddar-cheese", ...],
+        "shoppingList": {
+            "eggs": 1000,
+            "milk": 6,
+            ...
+        }
+    }
+}
+```
+## Get ingredient
+This route is for getting the information on an existing ingredient.
+### Header
+```
+GET /ingredients/:ingredient HTTP/1.1
+...
+Accept: application/json
+...
+```
+### Header details
+":ingredient" is the ingredient's name. For example, if the name was "milk", then the URI would be `/ingredients/milk`.
+### Response
+A 200 status code will be returned if the ingredient was successfully retrieved.
+
+A 404 status code will be returned if the ingredient doesn't correspond to an existing ingredient.
+### Example response
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "Ingredient retrieval successful",
+    "ingredient": {
+        "name": "milk"
+        "units": "cups"
+        "imageUri": milk/image/resource/here.png
+    }
+}
+```
+## Get tag
+This route is for getting the information on an existing tag. Currently, the only information on a tag is its name, but this route exists in case more information for tags gets added in the future.
+### Header
+```
+GET /tags/:tag HTTP/1.1
+...
+Accept: application/json
+...
+```
+### Header details
+":tag" is the tag's name. For example, if the name was "breakfast", then the URI would be `/tags/breakfast`.
+### Response
+A 200 status code will be returned if the tag was successfully retrieved.
+
+A 404 status code will be returned if the tag doesn't correspond to an existing tag.
+### Example response
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "Tag retrieval successful",
+    "ingredient": {
+        "name": "breakfast"
+    }
+}
+```
+## Create recipe
+This route is for creating new recipes to be saved into the data access layer.
+### Header
+```
+POST /create/recipe HTTP/1.1
+...
+Content-type: application/json
+Accept: application/json
+...
+```
+### Body details
+The body will be JSON containing the recipe details, as well as the name of the user that created the recipe (`authorUsername`). Only the `authorUsername` and `presentationName` are required, but if other fields are left out, then the recipe will have fewer details. If `name` is excluded or null, then a unique recipe name will be assigned to the recipe.
+### Example body
+```
+{
+    "encryptedJwtToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    "recipe": {
+        "presentationName": "Tasty Cheese Omelette",
+        "authorUsername": "OmeletteLover2000"
+        "prepTime": 5,
+        "cookTime": 5,
+        "imageUri": "image/resource/here.png",
+        "numServings": 1,
+        "avgRating": 4.5,
+        "numRatings": 20,
+        "directions": [
+            "Crack eggs into bowl",
+            "Beat eggs",
+            "Start stove with temperature on medium",
+            ...
+        ],
+        "tags": [
+            "breakfast",
+            "quick",
+            ...
+        ],
+        "requiredIngredients": {
+            "egg": 2,
+            "cheddar-cheese": 0.75,
             ...
         }
     }
 }
 ```
 ### Response
-A 201 (Created) status code will be returned if the recipe was successfully created. The response will contain the unique recipe name assigned to the recipe (`assignedName`). A 400 (Bad request) status code will be returned if the recipe data is invalid. Recipe data is invalid if any of the following are true:
+A 201 (Created) status code will be returned if the recipe was successfully created. The response will contain the unique recipe name assigned to the recipe (`assignedName`). If any of the tags don't correspond to an existing tag name, then new tags will be created for them.
+
+A 400 (Bad request) status code will be returned if the recipe data is invalid. Recipe data is invalid if any of the following are true:
 * The `presentationName`, `authorUsername`, `encryptedJwtToken`, or `recipe` is missing or null.
 * A `name` is specified, but there already exists a recipe with the same `name`.
 * Any of the `directions` elements are null.
-* Any of the `tags` elements are null or don't correspond to existing tags.
-* Any of the `requiredIngredients` keys are null or don't correspond to existing ingredients.
-* Any of the `requiredIngredients` values are null.
+* Any of the `tags` elements are null.
+* Any of the `requiredIngredients` keys or values are null.
 * The `authorUsername` doesn't correspond to an existing user.
 
-Note: the fields `directions`, `tags`, and `requiredIngredients` can be null themselves; they just can't have null elements. A 401 (Unauthorized) status code will be returned if the JWT token from `encryptedJwtToken` is invalid.  
+A 404 (Not found) status code will be returned if any of the recipe's `requiredIngredients` keys don't correspond to existing ingredients.
+
+A 401 (Unauthorized) status code will be returned if the JWT token from `encryptedJwtToken` is invalid (not yet implemented).
+
+Note: the fields `directions`, `tags`, and `requiredIngredients` can be null themselves; they just can't have null elements.
 The response will also contain a message with some details about what happened when handling the request (i.e. what error occurred if any, etc.)
 ### Example response
 ```
@@ -133,7 +231,309 @@ Content-type: application/json
 ...
 
 {
-    "message": "Recipe creation successful",
-    "assignedName": "tasty_cheese_omelette2"
+    "message": "Recipe creation successful: the recipe was assigned a new unique (non-presentation) name",
+    "assignedName": "tasty-cheese-omelette2"
+}
+```
+
+## Create User
+This route is for creating a new user into the data access layer. This user won't start out with anything (i.e. they won't have any saved recipes, etc.).
+### Header
+```
+POST /create/user HTTP/1.1
+...
+Content-type: application/json
+...
+```
+### Body details
+The body will be JSON containing the username of the user, and their email address. The email address is optional.
+### Example body
+```json
+{
+  "username": "OmeletteLover2000",
+  "emailAddress": "ExampleEmail@aol.com"
+}
+```
+### Response
+A 201 (Created) status code will be returned if the user is successfully created. A 400 (Bad request) status code will be returned if the username is null, missing, or already taken.
+### Example response
+```
+HTTP/1.1 201 Created
+...
+Content-type: application/json
+...
+
+{
+    "message": "User creation successful"
+}
+```
+```
+HTTP/1.1 400 Bad request
+...
+Content-type: application/json
+...
+
+{
+    "message": "User creation unsuccessful: username was already taken"
+}
+```
+## Create Ingredient
+This route is for creating new ingredients to be saved into the data access layer.
+### Header
+```
+POST /create/ingredient HTTP/1.1
+...
+Content-type: application/json
+Accept: application/json
+...
+```
+### Body details
+The body will be JSON containing the ingredient name, what units it's measured in, and the URI of an image of it. Ingredient names are automatically converted to lowercase. The units are optional (for ingredients like "eggs"), and the image URI is optional.
+### Example body
+```json
+{
+    "name": "flour",
+    "units": "cups",
+    "imageUri": "[image uri goes here]"
+}
+```
+### Response
+A 201 (Created) status code will be returned if the ingredient is successfully created.
+
+A 400 (Bad request) status code is returned if the name is null, missing, or already taken. Since ingredient names are automatically converted to lowercase, requesting "Flour" when "flour" is already created results in a 400.
+### Example response
+```
+HTTP/1.1 201 Created
+...
+Content-type: application/json
+...
+
+{
+    "message": "Ingredient creation successful"
+}
+```
+## Create Tag
+This route is for creating new tags to be saved into the data access layer.
+### Header
+```
+POST /create/tag HTTP/1.1
+...
+Content-type: application/json
+Accept: application/json
+...
+```
+### Body details
+The body will be JSON containing the tag name. 
+### Example body
+```json
+{
+  "name": "breakfast"
+}
+```
+### Response
+A 201 (Created) status code will be returned if the tag is successfully created.
+
+A 400 (Bad request) is returned if the name is null, missing, or already taken.
+### Example response
+```
+HTTP/1.1 201 Created
+...
+Content-type: application/json
+...
+
+{
+    "message": "Tag creation successful"
+}
+```
+## Search for recipe
+This route is for searching for recipes (that aren't known yet to the user) based on given search terms.
+### Header
+```
+GET /search/recipes HTTP/1.1
+...
+Accept: application/json
+...
+```
+### Query parameters
+`terms`: what the search terms are. Each search term is separated by a "+".
+### Example request
+`/search/recipes?terms=cheese+omelette` will perform a search with the terms "cheese" and "omelette".
+### Response
+A 200 status code will be returned if the search was successful, even if no recipes matched with the search terms.
+
+A 400 status code will be returned if no search terms are given (ex. just `search/recipes`). The body will be in JSON.
+### Example responses
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "Search successful: recipes that matched were found",
+    "matches": [
+        {
+            "name": "tasty-cheese-omelette2",
+            "presentationName": "Tasty Cheese Omelette",
+            "authorUsername": "OmeletteLover2000"
+            "prepTime": 5,
+            "cookTime": 5,
+            "imageUri": "image/resource/here.png",
+            "numServings": 1,
+            "avgRating": 4.5,
+            "numRatings": 20,
+            "directions": [
+                "Crack eggs into bowl",
+                "Beat eggs",
+                "Start stove with temperature on medium",
+                ...
+            ],
+            "tags": [
+                "breakfast",
+                "quick",
+                ...
+            ],
+            "requiredIngredients": {
+                "egg": 2,
+                "cheddar-cheese": 0.75,
+                ...
+            }
+        },
+        ...
+    ]
+}
+```
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "Search successful: but no matching recipes were found",
+    "recipes": []
+}
+```
+Note that `prepTime` and `cookTime` are in minutes.
+## Bookmark Recipe
+This route is for having a user bookmark a recipe, so they can more easily retrive it later.
+### Header
+```
+POST /bookmark/recipe HTTP/1.1
+...
+Content-type: application/json
+Accept: application/json
+...
+```
+### Body details
+The body will be JSON containing the username of the user, and the unique name of the recipe they want to save.
+### Example body
+```json
+{
+    "username": "OmeletteLover2000",
+    "encryptedJwtToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    "recipe": "zesty-omelette"
+}
+```
+### Response
+A 200 status code will be returned if the recipe was successfully bookmarked.
+
+A 404 status code will be returned if the username or recipe name don't correspond to an existing user or recipe, respectively.
+
+A 400 (Bad request) will be returned if any of the fields are null or missing.
+
+A 401 (Unauthorized) status code will be returned if the JWT token from `encryptedJwtToken` is invalid.
+### Example response
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "Recipe bookmarking successful"
+}
+```
+## Add ingredients to shopping list
+This route is for having a user add ingredients to their shopping list.
+### Header
+```
+POST /shopping-list/add-ingredients HTTP/1.1
+...
+Content-type: application/json
+Accept: application/json
+...
+```
+### Body details
+The body will be JSON containing the username of the user, the ingredients they want to add to their shopping list, and the amounts for each ingredient that they want.
+### Example body
+```
+{
+  "username": "OmeletteLover2000",
+  "encryptedJwtToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+  "ingredients": {
+    "eggs": 24,
+    "cheddar-cheese": 2,
+    ...
+  }
+}
+```
+### Response
+A 200 status code will be returned if the ingredients are successfully added to the user's shopping list.
+
+A 404 status code will be returned if any of the ingredient names don't correspond to existing ingredients.
+
+A 400 (Bad request) will be returned if any of the fields are null or missing, or if any keys/values of the ingredients are null.
+
+A 401 (Unauthorized) status code will be returned if the JWT token from `encryptedJwtToken` is invalid.
+### Example response
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "Ingredients successfully added to shopping list"
+}
+```
+## Add recipe ingredients to shopping list
+This route is for having a user add a recipe's ingredients to their shopping list.
+### Header
+```
+POST /shopping-list/add-recipe-ingredients HTTP/1.1
+...
+Content-type: application/json
+Accept: application/json
+...
+```
+### Body details
+The body will be JSON containing the username of the user, the recipe whose ingredients they want to add to their shopping list, and if they only want to add the recipe's ingredients that they're currently missing.
+### Example body
+```
+{
+  "username": "OmeletteLover2000",
+  "encryptedJwtToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+  "recipe": "lovely-omelette",
+  "addOnlyMissingIngredients": true
+}
+```
+### Response
+A 200 status code will be returned if the recipe's ingredients are successfully added to the user's shopping list.
+
+A 404 status code will be returned if the username or recipe name doesn't correspond to an existing user or recipe, respectively.
+
+A 400 (Bad request) status code will be returned if any of the fields are missing or null.
+
+A 401 (Unauthorized) status code will be returned if the JWT token from encryptedJwtToken is invalid.
+### Example response
+```
+HTTP/1.1 200 OK
+...
+Content-type: application/json
+...
+
+{
+    "message": "Recipe's ingredients successfully added to shopping list"
 }
 ```

--- a/api_routes.md
+++ b/api_routes.md
@@ -291,7 +291,7 @@ Accept: application/json
 ...
 ```
 ### Body details
-The body will be JSON containing the ingredient name, what units it's measured in, and the URI of an image of it. Ingredient names are automatically converted to lowercase. The units are optional (for ingredients like "eggs"), and the image URI is optional.
+The body will be JSON containing the ingredient name, what units it's measured in, and the URI of an image of it. The units are optional (for ingredients like "eggs"), and the image URI is optional.
 ### Example body
 ```json
 {
@@ -303,7 +303,7 @@ The body will be JSON containing the ingredient name, what units it's measured i
 ### Response
 A 201 (Created) status code will be returned if the ingredient is successfully created.
 
-A 400 (Bad request) status code is returned if the name is null, missing, or already taken. Since ingredient names are automatically converted to lowercase, requesting "Flour" when "flour" is already created results in a 400.
+A 400 (Bad request) status code is returned if the name is null, missing, or already taken.
 ### Example response
 ```
 HTTP/1.1 201 Created

--- a/api_routes.md
+++ b/api_routes.md
@@ -3,6 +3,22 @@
 * Access these API routes by connecting to `localhost:4567` while running the backend.
 * Each request body and response body is in JSON.
 * Each request's response body will contain a `"message"` field with some details about what happened when handling the request (i.e. what error occurred if any, etc.)
+## Table of Contents
+1. [Get recipe](#get-recipe)
+2. [Get user](#get-user)
+3. [Get ingredient](#get-ingredient)
+4. [Get tag](#get-tag)
+5. [Create recipe](#create-recipe)
+6. [Create user](#create-user)
+7. [Create ingredient](#create-ingredient)
+8. [Create tag](#create-tag)
+9. [Search for recipe](#search-for-recipe)
+10. [Bookmark recipe](#bookmark-recipe)
+11. [Add ingredients to shopping list](#add-ingredients-to-shopping-list)
+12. [Add recipe ingredients to shopping list](#add-recipe-ingredients-to-shopping-list)
+
+<div id="get-recipe"></div>
+
 ## Get recipe
 This route is for getting the information of an existing recipe.
 ### Header
@@ -57,6 +73,8 @@ Content-type: application/json
     }
 }
 ```
+<div id="get-user"></div>
+
 ## Get user
 This route is for getting the information of an existing user. 
 ### Header
@@ -102,6 +120,8 @@ Content-type: application/json
     }
 }
 ```
+<div id="get-ingredient"></div>
+
 ## Get ingredient
 This route is for getting the information on an existing ingredient.
 ### Header
@@ -133,6 +153,8 @@ Content-type: application/json
     }
 }
 ```
+<div id="get-tag"></div>
+
 ## Get tag
 This route is for getting the information on an existing tag. Currently, the only information on a tag is its name, but this route exists in case more information for tags gets added in the future.
 ### Header
@@ -162,6 +184,8 @@ Content-type: application/json
     }
 }
 ```
+<div id="create-recipe"></div>
+
 ## Create recipe
 This route is for creating new recipes to be saved into the data access layer.
 ### Header
@@ -236,8 +260,9 @@ Content-type: application/json
     "createdTags": []
 }
 ```
+<div id="create-user"></div>
 
-## Create User
+## Create user
 This route is for creating a new user into the data access layer. This user won't start out with anything (i.e. they won't have any saved recipes, etc.).
 ### Header
 ```
@@ -280,7 +305,9 @@ Content-type: application/json
     "message": "User creation unsuccessful: username was already taken"
 }
 ```
-## Create Ingredient
+<div id="create-ingredient"></div>
+
+## Create ingredient
 This route is for creating new ingredients to be saved into the data access layer.
 ### Header
 ```
@@ -315,7 +342,9 @@ Content-type: application/json
     "message": "Ingredient creation successful"
 }
 ```
-## Create Tag
+<div id="create-tag"></div>
+
+## Create tag
 This route is for creating new tags to be saved into the data access layer.
 ### Header
 ```
@@ -348,6 +377,8 @@ Content-type: application/json
     "message": "Tag creation successful"
 }
 ```
+<div id="search-for-recipe"></div>
+
 ## Search for recipe
 This route is for searching for recipes (that aren't known yet to the user) based on given search terms.
 ### Header
@@ -418,7 +449,9 @@ Content-type: application/json
 }
 ```
 Note that `prepTime` and `cookTime` are in minutes.
-## Bookmark Recipe
+<div id="bookmark-recipe"></div>
+
+## Bookmark recipe
 This route is for having a user bookmark a recipe, so they can more easily retrive it later.
 ### Header
 ```
@@ -457,6 +490,8 @@ Content-type: application/json
     "message": "Recipe bookmarking successful"
 }
 ```
+<div id="add-ingredients-to-shopping-list"></div>
+
 ## Add ingredients to shopping list
 This route is for having a user add ingredients to their shopping list.
 ### Header
@@ -500,6 +535,8 @@ Content-type: application/json
     "message": "Ingredients successfully added to shopping list"
 }
 ```
+<div id="add-recipe-ingredients-to-shopping-list"></div>
+
 ## Add recipe ingredients to shopping list
 This route is for having a user add a recipe's ingredients to their shopping list.
 ### Header

--- a/api_routes.md
+++ b/api_routes.md
@@ -41,14 +41,14 @@ Content-type: application/json
                 "Start stove with temperature on medium",
                 ...
             ],
-            "tags": {
-                {"name": "breakfast"},
-                {"name": "quick"},
+            "tags": [
+                "breakfast",
+                "quick",
                 ...
-            },
+            ],
             "requiredIngredients": {
-                {"name": "egg", "units": "eggs", "imageUri": "..."}: 2,
-                {"name": "cheese", "units": "cups", "imageUri": "..."}: 0.75,
+                "egg": 2,
+                "cheese": 0.75,
                 ...
             }
         },
@@ -100,11 +100,11 @@ The body will be JSON containing the recipe details, as well as the name of the 
             "Start stove with temperature on medium",
             ...
         ],
-        "tags": {
+        "tags": [
             "breakfast",
             "quick",
             ...
-        },
+        ],
         "requiredIngredients": {
             "egg": 2,
             "cheese": 0.75,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.warning.mode=all
+# the following line obtained from Doan Bui's solution in https://stackoverflow.com/questions/70423297/java-lang-illegalaccesserror-class-org-gradle-internal-compiler-java-classnamec, to fix an error with the running of ./gradlew
 org.gradle.jvmargs=-Xmx1536M --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED

--- a/src/checklist.md
+++ b/src/checklist.md
@@ -12,18 +12,18 @@
     - [x] Write the API route for this use case
     - [x] Implement this API route in HttpRequestHandler
 - [ ] Implement the "Save/bookmark recipe" use case
-    - [ ] Write tests for BookmarkRecipeCommand
-    - [ ] Implement BookmarkRecipeCommand
+    - [x] Write tests for BookmarkRecipeCommand
+    - [x] Implement BookmarkRecipeCommand
     - [x] Write the API route for this use case
     - [ ] Implement this API route in HttpRequestHandler
 - [ ] Implement the "Add ingredients to shopping list" use case
-    - [ ] Write tests for AddIngredientsToShoppingListCommand
-    - [ ] Implement AddIngredientsToShoppingListCommand
+    - [x] Write tests for AddIngredientsToShoppingListCommand
+    - [x] Implement AddIngredientsToShoppingListCommand
     - [x] Write the API route for this use case
     - [ ] Implement this API route in HttpRequestHandler
 - [ ] Implement the "Add recipe ingredients to shopping list" use case
-    - [ ] Write tests for AddRecipeToShoppingListCommand
-    - [ ] Implement AddRecipeToShoppingListCommand
+    - [x] Write tests for AddRecipeToShoppingListCommand
+    - [x] Implement AddRecipeToShoppingListCommand
     - [x] Write the API route for this use case
     - [ ] Implement this API route in HttpRequestHandler
 

--- a/src/checklist.md
+++ b/src/checklist.md
@@ -14,17 +14,17 @@
 - [ ] Implement the "Save/bookmark recipe" use case
     - [ ] Write tests for BookmarkRecipeCommand
     - [ ] Implement BookmarkRecipeCommand
-    - [ ] Write the API route for this use case
+    - [x] Write the API route for this use case
     - [ ] Implement this API route in HttpRequestHandler
 - [ ] Implement the "Add ingredients to shopping list" use case
     - [ ] Write tests for AddIngredientsToShoppingListCommand
     - [ ] Implement AddIngredientsToShoppingListCommand
-    - [ ] Write the API route for this use case
+    - [x] Write the API route for this use case
     - [ ] Implement this API route in HttpRequestHandler
 - [ ] Implement the "Add recipe ingredients to shopping list" use case
     - [ ] Write tests for AddRecipeToShoppingListCommand
     - [ ] Implement AddRecipeToShoppingListCommand
-    - [ ] Write the API route for this use case
+    - [x] Write the API route for this use case
     - [ ] Implement this API route in HttpRequestHandler
 
 ### Mongo database connectivity

--- a/src/checklist.md
+++ b/src/checklist.md
@@ -11,21 +11,21 @@
     - [x] Implement CreateRecipeCommand
     - [x] Write the API route for this use case
     - [x] Implement this API route in HttpRequestHandler
-- [ ] Implement the "Save/bookmark recipe" use case
+- [x] Implement the "Save/bookmark recipe" use case
     - [x] Write tests for BookmarkRecipeCommand
     - [x] Implement BookmarkRecipeCommand
     - [x] Write the API route for this use case
-    - [ ] Implement this API route in HttpRequestHandler
-- [ ] Implement the "Add ingredients to shopping list" use case
+    - [x] Implement this API route in HttpRequestHandler
+- [x] Implement the "Add ingredients to shopping list" use case
     - [x] Write tests for AddIngredientsToShoppingListCommand
     - [x] Implement AddIngredientsToShoppingListCommand
     - [x] Write the API route for this use case
-    - [ ] Implement this API route in HttpRequestHandler
-- [ ] Implement the "Add recipe ingredients to shopping list" use case
+    - [x] Implement this API route in HttpRequestHandler
+- [x] Implement the "Add recipe ingredients to shopping list" use case
     - [x] Write tests for AddRecipeToShoppingListCommand
     - [x] Implement AddRecipeToShoppingListCommand
     - [x] Write the API route for this use case
-    - [ ] Implement this API route in HttpRequestHandler
+    - [x] Implement this API route in HttpRequestHandler
 
 ### Mongo database connectivity
 - [x] Write tests for the data access layer

--- a/src/main/java/com/recipecart/Main.java
+++ b/src/main/java/com/recipecart/Main.java
@@ -1,7 +1,7 @@
 /* (C)2023 */
 package com.recipecart;
 
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.entities.Ingredient;
 import com.recipecart.entities.Recipe;
 import com.recipecart.entities.Tag;
@@ -19,7 +19,7 @@ public class Main {
     public static final int PORT = 4567;
 
     public static void main(String[] args) {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         putInMockData(saveAndLoader);
 
         EntityStorage storage = new EntityStorage(saveAndLoader, saveAndLoader);
@@ -30,7 +30,7 @@ public class Main {
         requestHandler.startHandler();
     }
 
-    private static void putInMockData(MockEntitySaveAndLoader saveAndLoader) {
+    private static void putInMockData(MapEntitySaveAndLoader saveAndLoader) {
         List<Tag> tags = new ArrayList<>();
         for (String s : List.of("Tag1", "Tag2", "Tag3", "Tag4", "Tag5")) {
             tags.add(new Tag(s));

--- a/src/main/java/com/recipecart/database/FileEntitySaveAndLoader.java
+++ b/src/main/java/com/recipecart/database/FileEntitySaveAndLoader.java
@@ -1,0 +1,233 @@
+/* (C)2023 */
+package com.recipecart.database;
+
+import com.recipecart.entities.Ingredient;
+import com.recipecart.entities.Recipe;
+import com.recipecart.entities.Tag;
+import com.recipecart.entities.User;
+import com.recipecart.utils.RecipeForm;
+import com.recipecart.utils.UserForm;
+import com.recipecart.utils.Utils;
+import java.io.*;
+import java.util.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class expands upon MapEntitySaveAndLoader's functionality by being able to save/load the
+ * entities to/from a file.
+ */
+public class FileEntitySaveAndLoader extends MapEntitySaveAndLoader {
+    private final @Nullable String autosaveFilename;
+    private final @Nullable Integer maxSaveCounter;
+    private Integer saveCounter;
+
+    /**
+     * Creates a FileEntitySaveAndLoader that starts off with no contents. This instance will
+     * autosave its contents to the given file every saveCounter method calls of an EntitySaver
+     * method.
+     *
+     * @param saveCounter the number of EntitySaver method calls required to autosave
+     * @throws IllegalArgumentException if saveCounter is negative
+     */
+    public FileEntitySaveAndLoader(@NotNull String filename, @NotNull Integer saveCounter) {
+        super();
+
+        Objects.requireNonNull(filename);
+        Objects.requireNonNull(saveCounter);
+        if (saveCounter < 0) {
+            throw new IllegalArgumentException("Max save counter cannot be negative");
+        }
+
+        this.autosaveFilename = filename;
+        this.maxSaveCounter = saveCounter;
+        this.saveCounter = 0;
+    }
+
+    /**
+     * Creates a FileEntitySaveAndLoader that starts off with no contents. This instance will do no
+     * autosaving.
+     */
+    public FileEntitySaveAndLoader() {
+        super();
+        this.autosaveFilename = null;
+        this.maxSaveCounter = null;
+        this.saveCounter = 0;
+    }
+
+    /**
+     * @return the file this instance autosaves to, or null if this instance doesn't do autosaving.
+     */
+    @Nullable public String getAutosaveFilename() {
+        return autosaveFilename;
+    }
+
+    /**
+     * Loads the contents of the given file (i.e. the output file from a previous save call from
+     * some other FileEntitySaveAndLoader) into this FileEntitySaveAndLoader. The loaded contents
+     * will overwrite the current contents of this FileEntitySaveAndLoader.
+     *
+     * @param filename the file to save/load entities to/from
+     * @throws FileNotFoundException if the given file cannot be found, or if there's an error with
+     *     reading from the file.
+     * @throws ClassNotFoundException if
+     */
+    private void load(String filename) throws IOException, ClassNotFoundException {
+        Objects.requireNonNull(filename);
+        tagWriteLock.lock();
+        ingredientWriteLock.lock();
+        recipeWriteLock.lock();
+        userWriteLock.lock();
+        try {
+            ObjectInputStream objectReader = new ObjectInputStream(new FileInputStream(filename));
+            EntityFile fileObject = (EntityFile) objectReader.readObject();
+            objectReader.close();
+
+            getSavedTags().clear();
+            getSavedTags().putAll(fileObject.getTags());
+
+            getSavedIngredients().clear();
+            getSavedIngredients().putAll(fileObject.getIngredients());
+
+            Map<String, Recipe> recipes = fileObject.getFromRecipeForms();
+            getSavedRecipes().clear();
+            getSavedRecipes().putAll(recipes);
+
+            Map<String, User> user = fileObject.getFromUserForms(recipes);
+            getSavedUsers().clear();
+            getSavedUsers().putAll(user);
+        } finally {
+            userWriteLock.unlock();
+            recipeWriteLock.unlock();
+            ingredientWriteLock.unlock();
+            tagWriteLock.unlock();
+        }
+    }
+
+    /**
+     * Saves the current contents of this instance to the given file. The file's original contents
+     * will be overwritten.
+     *
+     * @param filename the name of the file to save to
+     * @throws IOException if there's an error with writing to the file.
+     */
+    public void save(String filename) throws IOException {
+        Objects.requireNonNull(filename);
+        tagWriteLock.lock();
+        ingredientWriteLock.lock();
+        recipeWriteLock.lock();
+        userWriteLock.lock();
+        try {
+            EntityFile fileObject =
+                    new EntityFile(
+                            getSavedTags(),
+                            getSavedIngredients(),
+                            Utils.toRecipeFormMap(getSavedRecipes()),
+                            Utils.toUserFormMap(getSavedUsers()));
+
+            ObjectOutputStream objectWriter =
+                    new ObjectOutputStream(new FileOutputStream(filename));
+            objectWriter.writeObject(fileObject);
+            objectWriter.flush();
+            objectWriter.close();
+        } finally {
+            userWriteLock.unlock();
+            recipeWriteLock.unlock();
+            ingredientWriteLock.unlock();
+            tagWriteLock.unlock();
+        }
+    }
+
+    private void incrementSaveCounter() {
+        if (maxSaveCounter != null) {
+            synchronized (maxSaveCounter) {
+                try {
+                    if (Objects.equals(++saveCounter, maxSaveCounter)) {
+                        save(getAutosaveFilename());
+                        saveCounter = 0;
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void updateTags(@NotNull Collection<@NotNull Tag> tags) {
+        super.updateTags(tags);
+        incrementSaveCounter();
+    }
+
+    @Override
+    public void updateIngredients(@NotNull Collection<@NotNull Ingredient> ingredients) {
+        super.updateIngredients(ingredients);
+        incrementSaveCounter();
+    }
+
+    @Override
+    public void updateRecipes(@NotNull Collection<@NotNull Recipe> recipes) {
+        super.updateRecipes(recipes);
+        incrementSaveCounter();
+    }
+
+    @Override
+    public void updateUsers(@NotNull Collection<@NotNull User> users) {
+        super.updateUsers(users);
+        incrementSaveCounter();
+    }
+
+    private static class EntityFile implements Serializable {
+        private static final long serialVersionUID = 0xcafef00dL;
+
+        private final @NotNull Map<String, Tag> tags;
+        private final @NotNull Map<String, Ingredient> ingredients;
+        private final @NotNull Map<String, RecipeForm> recipeForms;
+        private final @NotNull Map<String, UserForm> userForms;
+
+        public EntityFile(
+                @NotNull Map<String, Tag> tags,
+                @NotNull Map<String, Ingredient> ingredients,
+                @NotNull Map<String, RecipeForm> recipes,
+                @NotNull Map<String, UserForm> users) {
+            this.tags = new HashMap<>(tags);
+            this.ingredients = new HashMap<>(ingredients);
+            this.recipeForms = new HashMap<>(recipes);
+            this.userForms = new HashMap<>(users);
+        }
+
+        public Map<String, Tag> getTags() {
+            return Collections.unmodifiableMap(tags);
+        }
+
+        public Map<String, Ingredient> getIngredients() {
+            return Collections.unmodifiableMap(ingredients);
+        }
+
+        public Map<String, RecipeForm> getRecipeForms() {
+            return Collections.unmodifiableMap(recipeForms);
+        }
+
+        public Map<String, UserForm> getUserForms() {
+            return Collections.unmodifiableMap(userForms);
+        }
+
+        public Map<String, Recipe> getFromRecipeForms() {
+            Map<String, Recipe> recipes = new HashMap<>();
+            for (Map.Entry<String, RecipeForm> entry : recipeForms.entrySet()) {
+                Recipe recipe = Utils.fromRecipeForm(entry.getValue(), tags, ingredients);
+                recipes.put(entry.getKey(), recipe);
+            }
+            return recipes;
+        }
+
+        public Map<String, User> getFromUserForms(Map<String, Recipe> recipes) {
+            Map<String, User> users = new HashMap<>();
+            for (Map.Entry<String, UserForm> entry : userForms.entrySet()) {
+                User user = Utils.fromUserForm(entry.getValue(), ingredients, recipes);
+                users.put(entry.getKey(), user);
+            }
+            return users;
+        }
+    }
+}

--- a/src/main/java/com/recipecart/database/MapEntitySaveAndLoader.java
+++ b/src/main/java/com/recipecart/database/MapEntitySaveAndLoader.java
@@ -21,7 +21,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
             ingredientLock = new ReentrantReadWriteLock(),
             recipeLock = new ReentrantReadWriteLock(),
             userLock = new ReentrantReadWriteLock();
-    private final Lock tagReadLock = tagLock.readLock(),
+    protected final Lock tagReadLock = tagLock.readLock(),
             ingredientReadLock = ingredientLock.readLock(),
             recipeReadLock = recipeLock.readLock(),
             userReadLock = userLock.readLock(),
@@ -40,6 +40,22 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         this.savedIngredients = new ConcurrentHashMap<>();
         this.savedRecipes = new ConcurrentHashMap<>();
         this.savedUsers = new ConcurrentHashMap<>();
+    }
+
+    protected Map<String, Tag> getSavedTags() {
+        return savedTags;
+    }
+
+    protected Map<String, Ingredient> getSavedIngredients() {
+        return savedIngredients;
+    }
+
+    protected Map<String, Recipe> getSavedRecipes() {
+        return savedRecipes;
+    }
+
+    protected Map<String, User> getSavedUsers() {
+        return savedUsers;
     }
 
     private static <K, V> List<V> getByIds(@NotNull List<@NotNull K> ids, Map<K, V> saved)
@@ -64,7 +80,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         List<Tag> tags;
         tagReadLock.lock();
         try {
-            tags = getByIds(names, savedTags);
+            tags = getByIds(names, getSavedTags());
         } finally {
             tagReadLock.unlock();
         }
@@ -77,7 +93,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         List<Ingredient> ingredients;
         ingredientReadLock.lock();
         try {
-            ingredients = getByIds(names, savedIngredients);
+            ingredients = getByIds(names, getSavedIngredients());
         } finally {
             ingredientReadLock.unlock();
         }
@@ -90,7 +106,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         List<Recipe> recipes;
         recipeReadLock.lock();
         try {
-            recipes = getByIds(names, savedRecipes);
+            recipes = getByIds(names, getSavedRecipes());
         } finally {
             recipeReadLock.unlock();
         }
@@ -103,7 +119,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         List<User> users;
         userReadLock.lock();
         try {
-            users = getByIds(usernames, savedUsers);
+            users = getByIds(usernames, getSavedUsers());
         } finally {
             userReadLock.unlock();
         }
@@ -117,7 +133,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         boolean exists;
         tagReadLock.lock();
         try {
-            exists = savedTags.containsKey(name);
+            exists = getSavedTags().containsKey(name);
         } finally {
             tagReadLock.unlock();
         }
@@ -131,7 +147,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         boolean exists;
         ingredientReadLock.lock();
         try {
-            exists = savedIngredients.containsKey(name);
+            exists = getSavedIngredients().containsKey(name);
         } finally {
             ingredientReadLock.unlock();
         }
@@ -145,7 +161,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         boolean exists;
         recipeReadLock.lock();
         try {
-            exists = savedRecipes.containsKey(name);
+            exists = getSavedRecipes().containsKey(name);
         } finally {
             recipeReadLock.unlock();
         }
@@ -159,7 +175,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         boolean exists;
         userReadLock.lock();
         try {
-            exists = savedUsers.containsKey(name);
+            exists = getSavedUsers().containsKey(name);
         } finally {
             userReadLock.unlock();
         }
@@ -211,8 +227,8 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         Set<Tag> matchedTags;
         tagReadLock.lock();
         try {
-            Set<String> matchedNames = findMatches(savedTags.keySet(), tokens, true);
-            matchedTags = getValuesOf(matchedNames, savedTags);
+            Set<String> matchedNames = findMatches(getSavedTags().keySet(), tokens, true);
+            matchedTags = getValuesOf(matchedNames, getSavedTags());
         } finally {
             tagReadLock.unlock();
         }
@@ -225,8 +241,8 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         Set<Ingredient> matchedIngredients;
         ingredientReadLock.lock();
         try {
-            Set<String> matchedNames = findMatches(savedIngredients.keySet(), tokens, true);
-            matchedIngredients = getValuesOf(matchedNames, savedIngredients);
+            Set<String> matchedNames = findMatches(getSavedIngredients().keySet(), tokens, true);
+            matchedIngredients = getValuesOf(matchedNames, getSavedIngredients());
         } finally {
             ingredientReadLock.unlock();
         }
@@ -251,10 +267,10 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         final boolean ignoreCase = true;
         recipeReadLock.lock();
         try {
-            Set<String> matchedNames = findMatches(savedRecipes.keySet(), tokens, ignoreCase);
-            matchedRecipes = getValuesOf(matchedNames, savedRecipes);
+            Set<String> matchedNames = findMatches(getSavedRecipes().keySet(), tokens, ignoreCase);
+            matchedRecipes = getValuesOf(matchedNames, getSavedRecipes());
             Set<Recipe> matchedPresentationRecipes =
-                    savedRecipes.values().stream()
+                    getSavedRecipes().values().stream()
                             .filter((recipe) -> matchesPresentationName(recipe, tokens, ignoreCase))
                             .collect(Collectors.toSet());
 
@@ -270,8 +286,8 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         Set<User> matchedUsers;
         userReadLock.lock();
         try {
-            Set<String> matchedNames = findMatches(savedUsers.keySet(), tokens, true);
-            matchedUsers = getValuesOf(matchedNames, savedUsers);
+            Set<String> matchedNames = findMatches(getSavedUsers().keySet(), tokens, true);
+            matchedUsers = getValuesOf(matchedNames, getSavedUsers());
         } finally {
             userReadLock.unlock();
         }
@@ -287,7 +303,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         tagWriteLock.lock();
         try {
             for (Tag tag : tags) {
-                savedTags.put(tag.getName(), tag);
+                getSavedTags().put(tag.getName(), tag);
             }
         } finally {
             tagWriteLock.unlock();
@@ -305,7 +321,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         ingredientWriteLock.lock();
         try {
             for (Ingredient ingredient : ingredients) {
-                savedIngredients.put(ingredient.getName(), ingredient);
+                getSavedIngredients().put(ingredient.getName(), ingredient);
             }
         } finally {
             ingredientWriteLock.unlock();
@@ -321,7 +337,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         recipeWriteLock.lock();
         try {
             for (Recipe recipe : recipes) {
-                savedRecipes.put(recipe.getName(), recipe);
+                getSavedRecipes().put(recipe.getName(), recipe);
             }
         } finally {
             recipeWriteLock.unlock();
@@ -337,7 +353,7 @@ public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
         userWriteLock.lock();
         try {
             for (User user : users) {
-                savedUsers.put(user.getUsername(), user);
+                getSavedUsers().put(user.getUsername(), user);
             }
         } finally {
             userWriteLock.unlock();

--- a/src/main/java/com/recipecart/database/MapEntitySaveAndLoader.java
+++ b/src/main/java/com/recipecart/database/MapEntitySaveAndLoader.java
@@ -15,11 +15,8 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * This class implements the storage EntitySaver and EntityLoader using a Map. This class is meant
- * to be used for testing other parts of the backend.
- */
-public class MockEntitySaveAndLoader implements EntitySaver, EntityLoader {
+/** This class implements the storage EntitySaver and EntityLoader using a Map. */
+public class MapEntitySaveAndLoader implements EntitySaver, EntityLoader {
     private final ReadWriteLock tagLock = new ReentrantReadWriteLock(),
             ingredientLock = new ReentrantReadWriteLock(),
             recipeLock = new ReentrantReadWriteLock(),
@@ -38,7 +35,7 @@ public class MockEntitySaveAndLoader implements EntitySaver, EntityLoader {
     private final Map<String, Recipe> savedRecipes;
     private final Map<String, User> savedUsers;
 
-    public MockEntitySaveAndLoader() {
+    public MapEntitySaveAndLoader() {
         this.savedTags = new ConcurrentHashMap<>();
         this.savedIngredients = new ConcurrentHashMap<>();
         this.savedRecipes = new ConcurrentHashMap<>();

--- a/src/main/java/com/recipecart/requests/HttpRequestHandler.java
+++ b/src/main/java/com/recipecart/requests/HttpRequestHandler.java
@@ -7,7 +7,11 @@ import com.google.gson.Gson;
 import com.recipecart.entities.Recipe;
 import com.recipecart.execution.EntityCommander;
 import com.recipecart.usecases.*;
+import com.recipecart.utils.RecipeForm;
 import com.recipecart.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
@@ -105,7 +109,13 @@ public class HttpRequestHandler {
         SearchRecipesCommand searchRecipesCommand = new SearchRecipesCommand(searchTerms);
         String message = handleCommand(searchRecipesCommand, response);
 
-        return new ResponseBodies.RecipeSearch(message, searchRecipesCommand.getMatchingRecipes());
+        if (searchRecipesCommand.getMatchingRecipes() != null) {
+            List<RecipeForm> matches = new ArrayList<>();
+            searchRecipesCommand.getMatchingRecipes().forEach((match) -> matches.add(new RecipeForm(match)));
+            return new ResponseBodies.RecipeSearch(message, matches);
+        } else {
+            return new ResponseBodies.RecipeSearch(message, null);
+        }
     }
 
     private Object handleCreateRecipeRequest(Request request, Response response) {

--- a/src/main/java/com/recipecart/requests/HttpRequestHandler.java
+++ b/src/main/java/com/recipecart/requests/HttpRequestHandler.java
@@ -41,7 +41,11 @@ public class HttpRequestHandler {
                     CreateRecipeCommand.OK_RECIPE_CREATED_WITH_GIVEN_NAME,
                     201,
                     CreateRecipeCommand.OK_RECIPE_CREATED_NAME_ASSIGNED,
-                    201);
+                    201,
+                    CreateRecipeCommand.NOT_OK_INVALID_RECIPE,
+                    400,
+                    CreateRecipeCommand.NOT_OK_NAME_TAKEN,
+                    400);
 
     private final @NotNull EntityCommander commander;
     private final @NotNull JwtValidator loginChecker;
@@ -70,7 +74,7 @@ public class HttpRequestHandler {
     public void startHandler() {
         port(listenPort);
         get("/search/recipes", APPLICATION_JSON, this::handleSearchRecipesRequest, gson::toJson);
-        post("/recipes/create", APPLICATION_JSON, this::handleCreateRecipeRequest, gson::toJson);
+        post("/create/recipe", APPLICATION_JSON, this::handleCreateRecipeRequest, gson::toJson);
     }
 
     private boolean isAuthorized(RequestBodies.WithLoginRequired requestBodyDetails) {

--- a/src/main/java/com/recipecart/requests/HttpRequestHandler.java
+++ b/src/main/java/com/recipecart/requests/HttpRequestHandler.java
@@ -171,7 +171,7 @@ public class HttpRequestHandler {
     }
 
     private Object handleGetTagRequest(Request request, Response response) {
-        String tagName = request.queryParams(":tag");
+        String tagName = request.params(":tag");
 
         GetTagCommand command = new GetTagCommand(tagName);
         String executionMessage = handleCommand(command, response);
@@ -180,7 +180,7 @@ public class HttpRequestHandler {
     }
 
     private Object handleGetIngredientRequest(Request request, Response response) {
-        String ingredientName = request.queryParams(":ingredient");
+        String ingredientName = request.params(":ingredient");
 
         GetIngredientCommand command = new GetIngredientCommand(ingredientName);
         String executionMessage = handleCommand(command, response);
@@ -190,23 +190,23 @@ public class HttpRequestHandler {
     }
 
     private Object handleGetRecipeRequest(Request request, Response response) {
-        String recipeName = request.queryParams(":recipe");
+        String recipeName = request.params(":recipe");
 
         GetRecipeCommand command = new GetRecipeCommand(recipeName);
         String executionMessage = handleCommand(command, response);
 
         return new ResponseBodies.RecipeRetrieval(
-                executionMessage, new RecipeForm(command.getRetrievedEntity()));
+                executionMessage, Utils.allowNull(command.getRetrievedEntity(), RecipeForm::new));
     }
 
     private Object handleGetUserRequest(Request request, Response response) {
-        String username = request.queryParams(":user");
+        String username = request.params(":user");
 
         GetUserCommand command = new GetUserCommand(username);
         String executionMessage = handleCommand(command, response);
 
         return new ResponseBodies.UserRetrieval(
-                executionMessage, new UserForm(command.getRetrievedEntity()));
+                executionMessage, Utils.allowNull(command.getRetrievedEntity(), UserForm::new));
     }
 
     private static Map<String, Integer> initializeMessageToStatusCode() {

--- a/src/main/java/com/recipecart/requests/HttpRequestHandler.java
+++ b/src/main/java/com/recipecart/requests/HttpRequestHandler.java
@@ -9,6 +9,7 @@ import com.recipecart.entities.Tag;
 import com.recipecart.execution.EntityCommander;
 import com.recipecart.usecases.*;
 import com.recipecart.utils.RecipeForm;
+import com.recipecart.utils.UserForm;
 import com.recipecart.utils.Utils;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -60,6 +61,14 @@ public class HttpRequestHandler {
                 this::handleCreateIngredientRequest,
                 gson::toJson);
         post("/create/tag", APPLICATION_JSON, this::handleCreateTagRequest, gson::toJson);
+        get("/tags/:tag", APPLICATION_JSON, this::handleGetTagRequest, gson::toJson);
+        get(
+                "/ingredients/:ingredient",
+                APPLICATION_JSON,
+                this::handleGetIngredientRequest,
+                gson::toJson);
+        get("/recipes/:recipe", APPLICATION_JSON, this::handleGetRecipeRequest, gson::toJson);
+        get("/users/:user", APPLICATION_JSON, this::handleGetUserRequest, gson::toJson);
     }
 
     private boolean isAuthorized(RequestBodies.WithLoginRequired requestBodyDetails) {
@@ -161,29 +170,85 @@ public class HttpRequestHandler {
         return new ResponseBodies.WithMessage(executionMessage);
     }
 
+    private Object handleGetTagRequest(Request request, Response response) {
+        String tagName = request.queryParams(":tag");
+
+        GetTagCommand command = new GetTagCommand(tagName);
+        String executionMessage = handleCommand(command, response);
+
+        return new ResponseBodies.TagRetrieval(executionMessage, command.getRetrievedEntity());
+    }
+
+    private Object handleGetIngredientRequest(Request request, Response response) {
+        String ingredientName = request.queryParams(":ingredient");
+
+        GetIngredientCommand command = new GetIngredientCommand(ingredientName);
+        String executionMessage = handleCommand(command, response);
+
+        return new ResponseBodies.IngredientRetrieval(
+                executionMessage, command.getRetrievedEntity());
+    }
+
+    private Object handleGetRecipeRequest(Request request, Response response) {
+        String recipeName = request.queryParams(":recipe");
+
+        GetRecipeCommand command = new GetRecipeCommand(recipeName);
+        String executionMessage = handleCommand(command, response);
+
+        return new ResponseBodies.RecipeRetrieval(
+                executionMessage, new RecipeForm(command.getRetrievedEntity()));
+    }
+
+    private Object handleGetUserRequest(Request request, Response response) {
+        String username = request.queryParams(":user");
+
+        GetUserCommand command = new GetUserCommand(username);
+        String executionMessage = handleCommand(command, response);
+
+        return new ResponseBodies.UserRetrieval(
+                executionMessage, new UserForm(command.getRetrievedEntity()));
+    }
+
     private static Map<String, Integer> initializeMessageToStatusCode() {
         Map<String, Integer> map = new HashMap<>();
 
         map.put(UNAUTHORIZED, 401);
         map.put(Command.NOT_OK_ERROR, 500);
         map.put(EntityCommand.NOT_OK_BAD_STORAGE, 500);
+
         map.put(SearchRecipesCommand.NOT_OK_BAD_SEARCH_TERMS, 400);
         map.put(SearchRecipesCommand.OK_MATCHES_FOUND, 200);
         map.put(SearchRecipesCommand.OK_NO_MATCHES_FOUND, 200);
+
         map.put(CreateRecipeCommand.OK_RECIPE_CREATED_WITH_GIVEN_NAME, 201);
         map.put(CreateRecipeCommand.OK_RECIPE_CREATED_NAME_ASSIGNED, 201);
         map.put(CreateRecipeCommand.NOT_OK_INVALID_RECIPE, 400);
         map.put(CreateRecipeCommand.NOT_OK_RECIPE_RESOURCES_NOT_FOUND, 404);
         map.put(CreateRecipeCommand.NOT_OK_RECIPE_NAME_TAKEN, 400);
+
         map.put(CreateTagCommand.OK_TAG_CREATED, 201);
         map.put(CreateTagCommand.NOT_OK_INVALID_TAG, 400);
         map.put(CreateTagCommand.NOT_OK_TAG_NAME_TAKEN, 400);
+
         map.put(CreateIngredientCommand.OK_INGREDIENT_CREATED, 201);
         map.put(CreateIngredientCommand.NOT_OK_INVALID_INGREDIENT, 400);
         map.put(CreateIngredientCommand.NOT_OK_INGREDIENT_NAME_TAKEN, 400);
+
         map.put(CreateUserCommand.OK_USER_CREATED, 201);
         map.put(CreateUserCommand.NOT_OK_INVALID_USER, 400);
         map.put(CreateUserCommand.NOT_OK_USERNAME_TAKEN, 400);
+
+        map.put(GetTagCommand.OK_TAG_RETRIEVED, 200);
+        map.put(GetTagCommand.NOT_OK_TAG_NOT_FOUND, 404);
+
+        map.put(GetIngredientCommand.OK_INGREDIENT_RETRIEVED, 200);
+        map.put(GetIngredientCommand.NOT_OK_INGREDIENT_NOT_FOUND, 404);
+
+        map.put(GetRecipeCommand.OK_RECIPE_RETRIEVED, 200);
+        map.put(GetRecipeCommand.NOT_OK_RECIPE_NOT_FOUND, 404);
+
+        map.put(GetUserCommand.OK_USER_RETRIEVED, 200);
+        map.put(GetUserCommand.NOT_OK_USER_NOT_FOUND, 404);
 
         return map;
     }

--- a/src/main/java/com/recipecart/requests/HttpRequestHandler.java
+++ b/src/main/java/com/recipecart/requests/HttpRequestHandler.java
@@ -4,6 +4,7 @@ package com.recipecart.requests;
 import static spark.Spark.*;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.recipecart.entities.Recipe;
 import com.recipecart.entities.Tag;
 import com.recipecart.execution.EntityCommander;
@@ -23,7 +24,7 @@ import spark.Response;
  * to perform that use case, then gives the front-end an output response.
  */
 public class HttpRequestHandler {
-    private static final int OK = 200,
+    static final int OK = 200,
             CREATED = 201,
             BAD_REQUEST = 400,
             UNAUTHORIZED = 401,
@@ -38,7 +39,7 @@ public class HttpRequestHandler {
     private final @NotNull JwtValidator loginChecker;
     private final int listenPort;
 
-    private final Gson gson = new Gson();
+    private final Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
 
     /**
      * Creates a handler that sends its commands to the given EntityCommander, validates logins with

--- a/src/main/java/com/recipecart/requests/HttpRequestHandler.java
+++ b/src/main/java/com/recipecart/requests/HttpRequestHandler.java
@@ -9,7 +9,6 @@ import com.recipecart.execution.EntityCommander;
 import com.recipecart.usecases.*;
 import com.recipecart.utils.RecipeForm;
 import com.recipecart.utils.Utils;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +110,9 @@ public class HttpRequestHandler {
 
         if (searchRecipesCommand.getMatchingRecipes() != null) {
             List<RecipeForm> matches = new ArrayList<>();
-            searchRecipesCommand.getMatchingRecipes().forEach((match) -> matches.add(new RecipeForm(match)));
+            searchRecipesCommand
+                    .getMatchingRecipes()
+                    .forEach((match) -> matches.add(new RecipeForm(match)));
             return new ResponseBodies.RecipeSearch(message, matches);
         } else {
             return new ResponseBodies.RecipeSearch(message, null);

--- a/src/main/java/com/recipecart/requests/HttpRequestHandler.java
+++ b/src/main/java/com/recipecart/requests/HttpRequestHandler.java
@@ -9,9 +9,10 @@ import com.recipecart.entities.Tag;
 import com.recipecart.execution.EntityCommander;
 import com.recipecart.usecases.*;
 import com.recipecart.utils.RecipeForm;
-import com.recipecart.utils.UserForm;
 import com.recipecart.utils.Utils;
 import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import spark.Request;
@@ -190,69 +191,65 @@ public class HttpRequestHandler {
     }
 
     private Object handleCreateUserRequest(Request request, Response response) {
-        RequestBodies.UserCreation bodyDetails =
-                getRequestBodyDetails(request, RequestBodies.UserCreation.class);
-
-        CreateUserCommand command =
-                new CreateUserCommand(bodyDetails.getUsername(), bodyDetails.getEmailAddress());
-        String executionMessage = handleCommand(command, response);
-
-        return new ResponseBodies.WithMessage(executionMessage);
+        return handleSimplePostRequest(
+                request,
+                response,
+                false,
+                RequestBodies.UserCreation.class,
+                (bodyDetails) ->
+                        new CreateUserCommand(
+                                bodyDetails.getUsername(), bodyDetails.getEmailAddress()));
     }
 
     private Object handleCreateIngredientRequest(Request request, Response response) {
-        RequestBodies.IngredientCreation bodyDetails =
-                getRequestBodyDetails(request, RequestBodies.IngredientCreation.class);
-
-        CreateIngredientCommand command =
-                new CreateIngredientCommand(
-                        bodyDetails.getName(), bodyDetails.getUnits(), bodyDetails.getImageUri());
-        String executionMessage = handleCommand(command, response);
-
-        return new ResponseBodies.WithMessage(executionMessage);
+        return handleSimplePostRequest(
+                request,
+                response,
+                false,
+                RequestBodies.IngredientCreation.class,
+                (bodyDetails) ->
+                        new CreateIngredientCommand(
+                                bodyDetails.getName(),
+                                bodyDetails.getUnits(),
+                                bodyDetails.getImageUri()));
     }
 
     private Object handleCreateTagRequest(Request request, Response response) {
-        RequestBodies.TagCreation bodyDetails =
-                getRequestBodyDetails(request, RequestBodies.TagCreation.class);
-
-        CreateTagCommand command = new CreateTagCommand(bodyDetails.getName());
-        String executionMessage = handleCommand(command, response);
-
-        return new ResponseBodies.WithMessage(executionMessage);
+        return handleSimplePostRequest(
+                request,
+                response,
+                false,
+                RequestBodies.TagCreation.class,
+                (bodyDetails) -> new CreateTagCommand(bodyDetails.getName()));
     }
 
     private Object handleGetTagRequest(Request request, Response response) {
-        String tagName = request.params(":tag");
-
-        GetTagCommand command = new GetTagCommand(tagName);
-        String executionMessage = handleCommand(command, response);
-
-        return new ResponseBodies.TagRetrieval(executionMessage, command.getRetrievedEntity());
+        return handleGetEntityRequest(
+                request, response, ":tag", GetTagCommand::new, ResponseBodies.TagRetrieval::new);
     }
 
     private Object handleGetIngredientRequest(Request request, Response response) {
-        String ingredientName = request.params(":ingredient");
-
-        GetIngredientCommand command = new GetIngredientCommand(ingredientName);
-        String executionMessage = handleCommand(command, response);
-
-        return new ResponseBodies.IngredientRetrieval(
-                executionMessage, command.getRetrievedEntity());
+        return handleGetEntityRequest(
+                request,
+                response,
+                ":ingredient",
+                GetIngredientCommand::new,
+                ResponseBodies.IngredientRetrieval::new);
     }
 
     private Object handleGetRecipeRequest(Request request, Response response) {
-        String recipeName = request.params(":recipe");
-
-        GetRecipeCommand command = new GetRecipeCommand(recipeName);
-        String executionMessage = handleCommand(command, response);
-
-        return new ResponseBodies.RecipeRetrieval(
-                executionMessage, Utils.allowNull(command.getRetrievedEntity(), RecipeForm::new));
+        return handleGetEntityRequest(
+                request,
+                response,
+                ":recipe",
+                GetRecipeCommand::new,
+                ResponseBodies.RecipeRetrieval::new);
     }
 
     private Object handleGetUserRequest(Request request, Response response) {
-        String username = request.params(":user");
+        return handleGetEntityRequest(
+                request, response, ":user", GetUserCommand::new, ResponseBodies.UserRetrieval::new);
+    }
 
     private Object handleBookmarkRecipeRequest(Request request, Response response) {
         return handleSimplePostRequest(

--- a/src/main/java/com/recipecart/requests/RequestBodies.java
+++ b/src/main/java/com/recipecart/requests/RequestBodies.java
@@ -2,6 +2,9 @@
 package com.recipecart.requests;
 
 import com.recipecart.utils.RecipeForm;
+import com.recipecart.utils.Utils;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * This helper class contains static Java class representations of the (JSON) bodies of various HTTP
@@ -87,6 +90,77 @@ class RequestBodies {
 
         String getName() {
             return name;
+        }
+    }
+
+    /** Follows the "Bookmark recipe" API route. */
+    static class RecipeBookmarking extends WithLoginRequired {
+        private final String username;
+        private final String recipe;
+
+        RecipeBookmarking(String encryptedJwtToken, String username, String recipe) {
+            super(encryptedJwtToken);
+            this.username = username;
+            this.recipe = recipe;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public String getRecipeName() {
+            return recipe;
+        }
+    }
+
+    /** Follows the "Add ingredients to shopping list" API route. */
+    static class IngredientToShoppingListAddition extends WithLoginRequired {
+        private final String username;
+        private final Map<String, Double> ingredients;
+
+        IngredientToShoppingListAddition(
+                String encryptedJwtToken, String username, Map<String, Double> ingredients) {
+            super(encryptedJwtToken);
+            this.username = username;
+            this.ingredients = ingredients;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public Map<String, Double> getIngredients() {
+            return Utils.allowNull(ingredients, Collections::unmodifiableMap);
+        }
+    }
+
+    /** Follows the "Add recipe ingredients to shopping list" API route. */
+    static class RecipeToShoppingListAddition extends WithLoginRequired {
+        private final String username;
+        private final String recipe;
+        private final Boolean addOnlyMissingIngredients;
+
+        RecipeToShoppingListAddition(
+                String encryptedJwtToken,
+                String username,
+                String recipe,
+                Boolean addOnlyMissingIngredients) {
+            super(encryptedJwtToken);
+            this.username = username;
+            this.recipe = recipe;
+            this.addOnlyMissingIngredients = addOnlyMissingIngredients;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public String getRecipeName() {
+            return recipe;
+        }
+
+        public Boolean isAddOnlyMissingIngredients() {
+            return addOnlyMissingIngredients;
         }
     }
 }

--- a/src/main/java/com/recipecart/requests/RequestBodies.java
+++ b/src/main/java/com/recipecart/requests/RequestBodies.java
@@ -35,4 +35,58 @@ class RequestBodies {
             return recipe;
         }
     }
+
+    /** Follows the "Create user" API route. */
+    static class UserCreation {
+        private final String username, emailAddress;
+
+        UserCreation(String username, String emailAddress) {
+            this.username = username;
+            this.emailAddress = emailAddress;
+        }
+
+        String getUsername() {
+            return username;
+        }
+
+        String getEmailAddress() {
+            return emailAddress;
+        }
+    }
+
+    /** Follows the "Create ingredient" API route. */
+    static class IngredientCreation {
+        private final String name, units, imageUri;
+
+        IngredientCreation(String name, String units, String imageUri) {
+            this.name = name;
+            this.units = units;
+            this.imageUri = imageUri;
+        }
+
+        String getName() {
+            return name;
+        }
+
+        String getUnits() {
+            return units;
+        }
+
+        String getImageUri() {
+            return imageUri;
+        }
+    }
+
+    /** Follows the "Create tag" API route. */
+    static class TagCreation {
+        private final String name;
+
+        TagCreation(String name) {
+            this.name = name;
+        }
+
+        String getName() {
+            return name;
+        }
+    }
 }

--- a/src/main/java/com/recipecart/requests/ResponseBodies.java
+++ b/src/main/java/com/recipecart/requests/ResponseBodies.java
@@ -1,7 +1,6 @@
 /* (C)2023 */
 package com.recipecart.requests;
 
-import com.recipecart.entities.Recipe;
 import com.recipecart.utils.RecipeForm;
 import com.recipecart.utils.Utils;
 import java.util.ArrayList;

--- a/src/main/java/com/recipecart/requests/ResponseBodies.java
+++ b/src/main/java/com/recipecart/requests/ResponseBodies.java
@@ -1,7 +1,10 @@
 /* (C)2023 */
 package com.recipecart.requests;
 
+import com.recipecart.entities.Ingredient;
+import com.recipecart.entities.Tag;
 import com.recipecart.utils.RecipeForm;
+import com.recipecart.utils.UserForm;
 import com.recipecart.utils.Utils;
 import java.util.*;
 import org.jetbrains.annotations.NotNull;
@@ -69,6 +72,58 @@ class ResponseBodies {
 
         Set<String> getCreatedTags() {
             return createdTags;
+        }
+    }
+
+    static class TagRetrieval extends WithMessage {
+        private final Tag retrievedTag;
+
+        TagRetrieval(@NotNull String message, Tag retrievedTag) {
+            super(message);
+            this.retrievedTag = retrievedTag;
+        }
+
+        Tag getRetrievedTag() {
+            return retrievedTag;
+        }
+    }
+
+    static class IngredientRetrieval extends WithMessage {
+        private final Ingredient retrievedIngredient;
+
+        IngredientRetrieval(@NotNull String message, Ingredient retrievedIngredient) {
+            super(message);
+            this.retrievedIngredient = retrievedIngredient;
+        }
+
+        Ingredient getRetrievedIngredient() {
+            return retrievedIngredient;
+        }
+    }
+
+    static class RecipeRetrieval extends WithMessage {
+        private final RecipeForm retrievedRecipe;
+
+        RecipeRetrieval(@NotNull String message, RecipeForm retrievedRecipeForm) {
+            super(message);
+            this.retrievedRecipe = retrievedRecipeForm;
+        }
+
+        RecipeForm getRetrievedRecipe() {
+            return retrievedRecipe;
+        }
+    }
+
+    static class UserRetrieval extends WithMessage {
+        private final UserForm retrievedUser;
+
+        UserRetrieval(@NotNull String message, UserForm retrievedUserForm) {
+            super(message);
+            this.retrievedUser = retrievedUserForm;
+        }
+
+        UserForm getRetrievedUser() {
+            return retrievedUser;
         }
     }
 }

--- a/src/main/java/com/recipecart/requests/ResponseBodies.java
+++ b/src/main/java/com/recipecart/requests/ResponseBodies.java
@@ -13,6 +13,19 @@ import org.jetbrains.annotations.NotNull;
  * change since those must be the same as the keys of the JSON objects they follow.
  */
 class ResponseBodies {
+    /**
+     * This is the base response, which its subclasses build upon. However, this class itself
+     * follows these API routes:
+     *
+     * <ul>
+     *   <li>"Create user"
+     *   <li>"Create ingredient"
+     *   <li>"Create tag"
+     *   <li>"Bookmark recipe"
+     *   <li>"Add ingredients to shopping list"
+     *   <li>"Add recipe ingredients to shopping list"
+     * </ul>
+     */
     static class WithMessage {
         private final @NotNull String message;
 

--- a/src/main/java/com/recipecart/requests/ResponseBodies.java
+++ b/src/main/java/com/recipecart/requests/ResponseBodies.java
@@ -2,7 +2,9 @@
 package com.recipecart.requests;
 
 import com.recipecart.entities.Ingredient;
+import com.recipecart.entities.Recipe;
 import com.recipecart.entities.Tag;
+import com.recipecart.entities.User;
 import com.recipecart.utils.RecipeForm;
 import com.recipecart.utils.UserForm;
 import com.recipecart.utils.Utils;
@@ -109,6 +111,10 @@ class ResponseBodies {
             this.retrievedRecipe = retrievedRecipeForm;
         }
 
+        RecipeRetrieval(@NotNull String message, Recipe retrievedRecipe) {
+            this(message, new RecipeForm(retrievedRecipe));
+        }
+
         RecipeForm getRetrievedRecipe() {
             return retrievedRecipe;
         }
@@ -120,6 +126,10 @@ class ResponseBodies {
         UserRetrieval(@NotNull String message, UserForm retrievedUserForm) {
             super(message);
             this.retrievedUser = retrievedUserForm;
+        }
+
+        UserRetrieval(@NotNull String message, User retrievedUser) {
+            this(message, new UserForm(retrievedUser));
         }
 
         UserForm getRetrievedUser() {

--- a/src/main/java/com/recipecart/requests/ResponseBodies.java
+++ b/src/main/java/com/recipecart/requests/ResponseBodies.java
@@ -2,6 +2,7 @@
 package com.recipecart.requests;
 
 import com.recipecart.entities.Recipe;
+import com.recipecart.utils.RecipeForm;
 import com.recipecart.utils.Utils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,14 +31,14 @@ class ResponseBodies {
 
     /** Follows the "Search for recipe" API route. */
     static class RecipeSearch extends WithMessage {
-        private final List<Recipe> matches;
+        private final List<RecipeForm> matches;
 
-        RecipeSearch(String message, Collection<Recipe> matches) {
+        RecipeSearch(String message, Collection<RecipeForm> matches) {
             super(message);
             this.matches = Utils.allowNull(matches, ArrayList::new);
         }
 
-        List<Recipe> getMatches() {
+        List<RecipeForm> getMatches() {
             return Collections.unmodifiableList(matches);
         }
     }

--- a/src/main/java/com/recipecart/requests/ResponseBodies.java
+++ b/src/main/java/com/recipecart/requests/ResponseBodies.java
@@ -112,7 +112,7 @@ class ResponseBodies {
         }
 
         RecipeRetrieval(@NotNull String message, Recipe retrievedRecipe) {
-            this(message, new RecipeForm(retrievedRecipe));
+            this(message, (RecipeForm) Utils.allowNull(retrievedRecipe, RecipeForm::new));
         }
 
         RecipeForm getRetrievedRecipe() {
@@ -129,7 +129,7 @@ class ResponseBodies {
         }
 
         UserRetrieval(@NotNull String message, User retrievedUser) {
-            this(message, new UserForm(retrievedUser));
+            this(message, (UserForm) Utils.allowNull(retrievedUser, UserForm::new));
         }
 
         UserForm getRetrievedUser() {

--- a/src/main/java/com/recipecart/requests/ResponseBodies.java
+++ b/src/main/java/com/recipecart/requests/ResponseBodies.java
@@ -3,10 +3,7 @@ package com.recipecart.requests;
 
 import com.recipecart.utils.RecipeForm;
 import com.recipecart.utils.Utils;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -45,14 +42,20 @@ class ResponseBodies {
     /** Follows the "Create recipe" API route. */
     static class RecipeCreation extends WithMessage {
         private final String assignedName;
+        private final Set<String> createdTags;
 
-        RecipeCreation(String message, String assignedName) {
+        RecipeCreation(String message, String assignedName, Set<String> createdTags) {
             super(message);
             this.assignedName = assignedName;
+            this.createdTags = createdTags;
         }
 
         String getAssignedName() {
             return assignedName;
+        }
+
+        Set<String> getCreatedTags() {
+            return createdTags;
         }
     }
 }

--- a/src/main/java/com/recipecart/usecases/AddIngredientsToShoppingListCommand.java
+++ b/src/main/java/com/recipecart/usecases/AddIngredientsToShoppingListCommand.java
@@ -1,18 +1,28 @@
 /* (C)2023 */
 package com.recipecart.usecases;
 
+import com.recipecart.entities.Ingredient;
+import com.recipecart.entities.User;
+import com.recipecart.utils.Utils;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.lang3.NotImplementedException;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This class represents an action item for the use case of a user adding ingredients to their
  * shopping list.
  */
 public final class AddIngredientsToShoppingListCommand extends ShoppingListCommand {
-    private final @NotNull Map<@NotNull String, @NotNull Double> ingredientsToAdd;
+    public static final String
+            NOT_OK_INVALID_INGREDIENTS =
+                    "Shopping list update unsuccessful: one of the given ingredient names is null"
+                            + " or invalid",
+            NOT_OK_INGREDIENT_NOT_FOUND =
+                    "Shopping list update unsuccessful: one of the given ingredient names don't"
+                            + " correspond to an existing ingredient";
+
+    private final Map<String, Double> ingredientsToAdd;
 
     /**
      * Creates the action item for a user to add ingredients to their shopping list.
@@ -22,26 +32,79 @@ public final class AddIngredientsToShoppingListCommand extends ShoppingListComma
      *     add
      */
     public AddIngredientsToShoppingListCommand(
-            @NotNull String shopperUsername,
-            @NotNull Map<@NotNull String, @NotNull Double> ingredientsToAdd) {
+            String shopperUsername, Map<String, Double> ingredientsToAdd) {
         super(shopperUsername);
-        this.ingredientsToAdd = new HashMap<>(ingredientsToAdd);
+        this.ingredientsToAdd = Utils.allowNull(ingredientsToAdd, HashMap::new);
     }
 
-    @NotNull public Map<@NotNull String, @NotNull Double> getIngredientsToAdd() {
-        return Collections.unmodifiableMap(ingredientsToAdd);
+    public Map<String, Double> getIngredientsToAdd() {
+        return Utils.allowNull(ingredientsToAdd, Collections::unmodifiableMap);
+    }
+
+    @Override
+    protected String getInvalidCommandMessage() {
+        String baseMessage = super.getInvalidCommandMessage();
+        if (baseMessage != null) {
+            return baseMessage;
+        }
+        if (!isIngredientsMapValid()) {
+            return NOT_OK_INVALID_INGREDIENTS;
+        }
+        try {
+            if (!doIngredientsExist()) {
+                return NOT_OK_INGREDIENT_NOT_FOUND;
+            }
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            return NOT_OK_ERROR;
+        }
+        return null;
+    }
+
+    private boolean isIngredientsMapValid() {
+        return getIngredientsToAdd() != null
+                && !getIngredientsToAdd().containsKey(null)
+                && !getIngredientsToAdd().containsValue(null);
+    }
+
+    private boolean doIngredientsExist() {
+        assert getStorageSource() != null;
+        return getIngredientsToAdd().keySet().stream()
+                .allMatch(getStorageSource().getLoader()::ingredientNameExists);
     }
 
     /**
      * Have the ingredients be added to the user's shopping list. If the given username is null or
      * has no associated user, or if any of the ingredient names are null don't correspond to
      * existing ingredients, or if any of the ingredient values are null, then this command's
-     * execution will be unsuccessful
+     * execution will be unsuccessful.
      *
      * @throws IllegalStateException if this method has been called before on this command instance.
      */
     @Override
     public void execute() {
-        throw new NotImplementedException();
+        super.execute();
+    }
+
+    protected Map<Ingredient, Double> performShoppingListUpdate() throws IOException {
+        User shopper = getShopper();
+        Map<Ingredient, Double> updatedShoppingList =
+                Utils.addMaps(shopper.getShoppingList(), getIngredients());
+        saveUpdatedShoppingList(shopper, updatedShoppingList);
+        return updatedShoppingList;
+    }
+
+    private Map<Ingredient, Double> getIngredients() throws IOException {
+        assert getStorageSource() != null;
+        Map<Ingredient, Double> ingredients = new HashMap<>();
+        for (Map.Entry<String, Double> entry : getIngredientsToAdd().entrySet()) {
+            Ingredient ingredient =
+                    getStorageSource()
+                            .getLoader()
+                            .getIngredientsByNames(Collections.singletonList(entry.getKey()))
+                            .get(0);
+            ingredients.put(ingredient, entry.getValue());
+        }
+        return ingredients;
     }
 }

--- a/src/main/java/com/recipecart/usecases/AddIngredientsToShoppingListCommand.java
+++ b/src/main/java/com/recipecart/usecases/AddIngredientsToShoppingListCommand.java
@@ -33,11 +33,12 @@ public final class AddIngredientsToShoppingListCommand extends ShoppingListComma
     }
 
     /**
-     * Have the ingredients be added to the user's shopping list.
+     * Have the ingredients be added to the user's shopping list. If the given username is null or
+     * has no associated user, or if any of the ingredient names are null don't correspond to
+     * existing ingredients, or if any of the ingredient values are null, then this command's
+     * execution will be unsuccessful
      *
      * @throws IllegalStateException if this method has been called before on this command instance.
-     * @throws IllegalArgumentException if the given username has no associated user, or if any of
-     *     the ingredient names don't correspond to existing ingredients
      */
     @Override
     public void execute() {

--- a/src/main/java/com/recipecart/usecases/AddRecipeToShoppingListCommand.java
+++ b/src/main/java/com/recipecart/usecases/AddRecipeToShoppingListCommand.java
@@ -1,15 +1,28 @@
 /* (C)2023 */
 package com.recipecart.usecases;
 
-import org.apache.commons.lang3.NotImplementedException;
-import org.jetbrains.annotations.NotNull;
+import com.recipecart.entities.Ingredient;
+import com.recipecart.entities.Recipe;
+import com.recipecart.entities.User;
+import com.recipecart.utils.Utils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class represents an action item for the use case of a user adding a specific recipe's
  * ingredients to their shopping list.
  */
 public final class AddRecipeToShoppingListCommand extends ShoppingListCommand {
-    private final @NotNull String recipeName;
+    public static final String
+            NOT_OK_INVALID_RECIPE =
+                    "Shopping list update unsuccessful: the given recipe name is null or invalid",
+            NOT_OK_RECIPE_NOT_FOUND =
+                    "Shopping list update unsuccessful: the given recipe name doesn't correspond to"
+                            + " an existing recipe";
+
+    private final String recipeName;
     private final boolean addOnlyMissingIngredients;
 
     /**
@@ -22,20 +35,47 @@ public final class AddRecipeToShoppingListCommand extends ShoppingListCommand {
      *     added; otherwise, add all the recipe's ingredients.
      */
     public AddRecipeToShoppingListCommand(
-            @NotNull String shopperUsername,
-            @NotNull String recipeName,
-            boolean addOnlyMissingIngredients) {
+            String shopperUsername, String recipeName, boolean addOnlyMissingIngredients) {
         super(shopperUsername);
         this.recipeName = recipeName;
         this.addOnlyMissingIngredients = addOnlyMissingIngredients;
     }
 
-    @NotNull public String getRecipeName() {
+    public String getRecipeName() {
         return recipeName;
     }
 
     public boolean isAddOnlyMissingIngredients() {
         return addOnlyMissingIngredients;
+    }
+
+    @Override
+    protected String getInvalidCommandMessage() {
+        String baseMessage = super.getInvalidCommandMessage();
+        if (baseMessage != null) {
+            return baseMessage;
+        }
+        if (!isRecipeValid()) {
+            return NOT_OK_INVALID_RECIPE;
+        }
+        try {
+            if (!doesRecipeExist()) {
+                return NOT_OK_RECIPE_NOT_FOUND;
+            }
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            return NOT_OK_ERROR;
+        }
+        return null;
+    }
+
+    private boolean isRecipeValid() {
+        return getRecipeName() != null;
+    }
+
+    private boolean doesRecipeExist() {
+        assert getStorageSource() != null;
+        return getStorageSource().getLoader().recipeNameExists(getRecipeName());
     }
 
     /**
@@ -47,6 +87,31 @@ public final class AddRecipeToShoppingListCommand extends ShoppingListCommand {
      */
     @Override
     public void execute() {
-        throw new NotImplementedException();
+        super.execute();
+    }
+
+    @Override
+    protected Map<Ingredient, Double> performShoppingListUpdate() throws IOException {
+        User shopper = getShopper();
+        Map<Ingredient, Double> updatedShoppingList = getUpdatedShoppingList(shopper);
+        saveUpdatedShoppingList(shopper, updatedShoppingList);
+        return updatedShoppingList;
+    }
+
+    private Map<Ingredient, Double> getUpdatedShoppingList(User shopper) throws IOException {
+        Map<Ingredient, Double> shoppingListUpdate = getRecipe().getRequiredIngredients();
+        if (isAddOnlyMissingIngredients()) {
+            shoppingListUpdate = new HashMap<>(shoppingListUpdate);
+            shoppingListUpdate.keySet().removeAll(shopper.getOwnedIngredients());
+        }
+        return Utils.addMaps(shopper.getShoppingList(), shoppingListUpdate);
+    }
+
+    private Recipe getRecipe() throws IOException {
+        assert getStorageSource() != null;
+        return getStorageSource()
+                .getLoader()
+                .getRecipesByNames(Collections.singletonList(getRecipeName()))
+                .get(0);
     }
 }

--- a/src/main/java/com/recipecart/usecases/AddRecipeToShoppingListCommand.java
+++ b/src/main/java/com/recipecart/usecases/AddRecipeToShoppingListCommand.java
@@ -39,11 +39,11 @@ public final class AddRecipeToShoppingListCommand extends ShoppingListCommand {
     }
 
     /**
-     * Have the recipe's ingredients be added to the user's shopping list.
+     * Have the recipe's ingredients be added to the user's shopping list. If the given username is
+     * null or has no associated user, or if the given recipe name is null or has no associated
+     * recipe, then this command's execution will be unsuccessful.
      *
      * @throws IllegalStateException if this method has been called before on this command instance.
-     * @throws IllegalArgumentException if the given username has no associated user, or if the
-     *     given recipe name has no associated recipe
      */
     @Override
     public void execute() {

--- a/src/main/java/com/recipecart/usecases/BookmarkRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/BookmarkRecipeCommand.java
@@ -1,20 +1,34 @@
 /* (C)2023 */
 package com.recipecart.usecases;
 
-import org.apache.commons.lang3.NotImplementedException;
-import org.jetbrains.annotations.NotNull;
+import com.recipecart.entities.Recipe;
+import com.recipecart.entities.User;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 /** This class represents an action item for the use case of a user bookmarking a recipe. */
 public final class BookmarkRecipeCommand extends EntityCommand {
-    public static final String OK_RECIPE_BOOKMARKED = "Recipe bookmarking successful.",
+    public static final String OK_RECIPE_BOOKMARKED = "Recipe bookmarking successful",
             NOT_OK_INVALID_RECIPE_NAME =
-                    "Recipe bookmarking unsuccessful: the given recipe name was null or invalid.",
+                    "Recipe bookmarking unsuccessful: the given recipe name was null or invalid",
             NOT_OK_INVALID_USERNAME =
                     "Recipe bookmarking unsuccessful: the username of the bookmark-er was null or"
-                            + " invalid.";
+                            + " invalid",
+            NOT_OK_RECIPE_NOT_FOUND =
+                    "Recipe bookmarking unsuccessful: the given recipe name doesn't correspond to"
+                            + " an existing recipe",
+            NOT_OK_USER_NOT_FOUND =
+                    "Recipe bookmarking unsuccessful: the given username doesn't correspond to an"
+                            + " existing user",
+            NOT_OK_RECIPE_ALREADY_BOOKMARKED =
+                    "Recipe bookmarking unsuccessful: the given user already has the given recipe"
+                            + " bookmarked";
 
-    private final @NotNull String bookmarkerUsername;
-    private final @NotNull String recipeName;
+    private final String bookmarkerUsername;
+    private final String recipeName;
 
     /**
      * Creates an action item for a username to bookmark a recipe.
@@ -22,17 +36,61 @@ public final class BookmarkRecipeCommand extends EntityCommand {
      * @param bookmarkerUsername the associated username of the given user
      * @param recipeName the associated (non-presentation) name of the given recipe
      */
-    public BookmarkRecipeCommand(@NotNull String bookmarkerUsername, @NotNull String recipeName) {
+    public BookmarkRecipeCommand(String bookmarkerUsername, String recipeName) {
         this.bookmarkerUsername = bookmarkerUsername;
         this.recipeName = recipeName;
     }
 
-    @NotNull public String getBookmarkerUsername() {
+    @Nullable public String getBookmarkerUsername() {
         return bookmarkerUsername;
     }
 
-    @NotNull public String getRecipeName() {
+    @Nullable public String getRecipeName() {
         return recipeName;
+    }
+
+    @Override
+    protected String getInvalidCommandMessage() {
+        String baseMessage = super.getInvalidCommandMessage();
+        if (baseMessage != null) {
+            return baseMessage;
+        }
+        if (!isUsernameValid()) {
+            return NOT_OK_INVALID_USERNAME;
+        }
+        if (!isRecipeNameValid()) {
+            return NOT_OK_INVALID_RECIPE_NAME;
+        }
+        try {
+            if (!doesUserExist()) {
+                return NOT_OK_USER_NOT_FOUND;
+            }
+            if (!doesRecipeExist()) {
+                return NOT_OK_RECIPE_NOT_FOUND;
+            }
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            return NOT_OK_ERROR;
+        }
+        return null;
+    }
+
+    private boolean isUsernameValid() {
+        return getBookmarkerUsername() != null;
+    }
+
+    private boolean isRecipeNameValid() {
+        return getRecipeName() != null;
+    }
+
+    private boolean doesUserExist() {
+        assert getStorageSource() != null;
+        return getStorageSource().getLoader().usernameExists(getBookmarkerUsername());
+    }
+
+    private boolean doesRecipeExist() {
+        assert getStorageSource() != null;
+        return getStorageSource().getLoader().recipeNameExists(getRecipeName());
     }
 
     /**
@@ -44,6 +102,79 @@ public final class BookmarkRecipeCommand extends EntityCommand {
      */
     @Override
     public void execute() {
-        throw new NotImplementedException();
+        checkExecutionAlreadyDone();
+        if (finishInvalidCommand()) {
+            return;
+        }
+
+        try {
+            if (!performBookmarking()) {
+                return;
+            }
+        } catch (RuntimeException e) {
+            finishExecutingFromError(e);
+            return;
+        } catch (IOException e) {
+            finishExecutingImpossibleOutcome(e);
+            return;
+        }
+
+        finishExecutingRecipeSuccessfullyBookmarked();
+    }
+
+    private boolean performBookmarking() throws IOException {
+        User bookmarker = getUser();
+        Recipe toBookmark = getRecipe();
+
+        if (isRecipeAlreadyBookmarked(bookmarker, toBookmark)) {
+            finishExecutingRecipeAlreadyBookmarked();
+            return false;
+        }
+
+        User updatedBookmarker = getUserWithRecipeBookmarked(bookmarker, toBookmark);
+        saveUser(updatedBookmarker);
+        return true;
+    }
+
+    private User getUser() throws IOException {
+        assert getStorageSource() != null;
+        return getStorageSource()
+                .getLoader()
+                .getUsersByNames(Collections.singletonList(getBookmarkerUsername()))
+                .get(0);
+    }
+
+    private Recipe getRecipe() throws IOException {
+        assert getStorageSource() != null;
+        return getStorageSource()
+                .getLoader()
+                .getRecipesByNames(Collections.singletonList(getRecipeName()))
+                .get(0);
+    }
+
+    private boolean isRecipeAlreadyBookmarked(User user, Recipe recipe) {
+        return user.getSavedRecipes().contains(recipe);
+    }
+
+    private User getUserWithRecipeBookmarked(User user, Recipe recipe) {
+        List<Recipe> savedRecipes = new ArrayList<>(user.getSavedRecipes());
+        savedRecipes.add(recipe);
+        return new User.Builder(user).setSavedRecipes(savedRecipes).build();
+    }
+
+    private void saveUser(User user) {
+        assert getStorageSource() != null;
+        getStorageSource().getSaver().updateUsers(Collections.singleton(user));
+    }
+
+    private void finishExecutingRecipeAlreadyBookmarked() {
+        setExecutionMessage(NOT_OK_RECIPE_ALREADY_BOOKMARKED);
+        finishExecuting();
+    }
+
+    private void finishExecutingRecipeSuccessfullyBookmarked() {
+        setExecutionMessage(OK_RECIPE_BOOKMARKED);
+        beSuccessful();
+        finishExecuting();
     }
 }

--- a/src/main/java/com/recipecart/usecases/BookmarkRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/BookmarkRecipeCommand.java
@@ -6,6 +6,13 @@ import org.jetbrains.annotations.NotNull;
 
 /** This class represents an action item for the use case of a user bookmarking a recipe. */
 public final class BookmarkRecipeCommand extends EntityCommand {
+    public static final String OK_RECIPE_BOOKMARKED = "Recipe bookmarking successful.",
+            NOT_OK_INVALID_RECIPE_NAME =
+                    "Recipe bookmarking unsuccessful: the given recipe name was null or invalid.",
+            NOT_OK_INVALID_USERNAME =
+                    "Recipe bookmarking unsuccessful: the username of the bookmark-er was null or"
+                            + " invalid.";
+
     private final @NotNull String bookmarkerUsername;
     private final @NotNull String recipeName;
 
@@ -29,12 +36,11 @@ public final class BookmarkRecipeCommand extends EntityCommand {
     }
 
     /**
-     * Has the user bookmark the recipe. If the user already bookmarked the recipe, this command's
-     * execution will be unsuccessful.
+     * Has the user bookmark the recipe. The command will be unsuccessful if the given username has
+     * no associated user, the given recipe name has no associated recipe, or if the user already
+     * bookmarked the recipe.
      *
      * @throws IllegalStateException if this method has been called before on this command instance.
-     * @throws IllegalArgumentException if the given username has no associated user, or the given
-     *     recipe name has no associated recipe.
      */
     @Override
     public void execute() {

--- a/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
@@ -2,136 +2,57 @@
 package com.recipecart.usecases;
 
 import com.recipecart.entities.Ingredient;
-import java.util.Collections;
-import java.util.Objects;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.recipecart.storage.EntityLoader;
+import com.recipecart.storage.EntitySaver;
+import java.util.Collection;
 
-public class CreateIngredientCommand extends EntityCommand {
+public class CreateIngredientCommand extends SimpleCreateEntityCommand<Ingredient> {
     public static final String OK_INGREDIENT_CREATED = "Ingredient creation successful",
             NOT_OK_INVALID_INGREDIENT =
                     "Ingredient creation unsuccessful: the ingredient was invalid or null",
             NOT_OK_INGREDIENT_NAME_TAKEN =
                     "Ingredient creation unsuccessful: the ingredient name is already taken";
 
-    private final Ingredient toAdd;
-    private Ingredient createdIngredient;
-
-    /**
-     * Creates an action item for a new Ingredient to be created and saved into the EntityStorage
-     * given to this command.
-     *
-     * @param toAdd the Ingredient to save
-     */
     public CreateIngredientCommand(Ingredient toAdd) {
-        this.toAdd = toAdd;
+        super(toAdd);
     }
 
-    /**
-     * Creates an action item for a new Ingredient to be created and saved into the EntityStorage
-     * given to this command.
-     *
-     * @param ingredientName the new, unique name of the Ingredient to save
-     * @param units the units of the Ingredient to save
-     * @param imageUri the URI of an image of the Ingredient to save
-     */
     public CreateIngredientCommand(String ingredientName, String units, String imageUri) {
         this(new Ingredient(ingredientName, units, imageUri));
     }
 
-    /**
-     * Returns the (output) Ingredient that was created/saved when executing this command.
-     *
-     * @throws IllegalStateException if this command instance hasn't finished executing yet.
-     * @return the (non-null) Ingredient that was created/saved, if the command successfully added
-     *     it; null otherwise.
-     */
-    @Nullable public Ingredient getCreatedIngredient() {
-        if (!isFinishedExecuting()) {
-            throw new IllegalStateException("Command hasn't finished executing yet");
-        }
-        return createdIngredient;
-    }
-
-    private void setCreatedIngredient(@NotNull Ingredient createdIngredient) {
-        if (isFinishedExecuting()) {
-            throw new IllegalStateException(
-                    "Cannot set the created tag after command has executed");
-        }
-        if (this.createdIngredient != null) {
-            throw new IllegalStateException("Can only set created tag once");
-        }
-        Objects.requireNonNull(createdIngredient);
-        this.createdIngredient = createdIngredient;
-    }
-
-    public Ingredient getToAdd() {
-        return toAdd;
+    @Override
+    protected String getOkEntityCreatedMessage() {
+        return OK_INGREDIENT_CREATED;
     }
 
     @Override
-    protected String getInvalidCommandMessage() {
-        String baseMessage = super.getInvalidCommandMessage();
-        if (baseMessage != null) {
-            return baseMessage;
-        }
-        if (!isIngredientValid()) {
-            return NOT_OK_INVALID_INGREDIENT;
-        }
-        try {
-            if (!isIngredientNameAvailable()) {
-                return NOT_OK_INGREDIENT_NAME_TAKEN;
-            }
-        } catch (RuntimeException e) { // for data access layer failures
-            e.printStackTrace();
-            return NOT_OK_ERROR;
-        }
-        return null;
+    protected String getNotOkInvalidEntityMessage() {
+        return NOT_OK_INVALID_INGREDIENT;
     }
 
-    private boolean isIngredientValid() {
-        return getToAdd() != null && getToAdd().getName() != null;
-    }
-
-    private boolean isIngredientNameAvailable() {
-        assert getStorageSource() != null;
-        assert getToAdd().getName() != null;
-        return !getStorageSource().getLoader().ingredientNameExists(getToAdd().getName());
-    }
-
-    /**
-     * Has the Ingredient be (created and) saved. If the ingredient name is null or corresponds to
-     * an already-existing ingredient, then this command's execution will be unsuccessful.
-     *
-     * @throws IllegalStateException if this method has been called before on this command instance.
-     */
     @Override
-    public void execute() {
-        checkExecutionAlreadyDone();
-        if (finishInvalidCommand()) {
-            return;
-        }
-
-        try {
-            saveIngredient(getToAdd());
-        } catch (RuntimeException e) {
-            finishExecutingFromError(e);
-            return;
-        }
-
-        finishExecutingSuccessfulIngredientCreation(getToAdd());
+    protected String getNotOkEntityNameAlreadyTakenMessage() {
+        return NOT_OK_INGREDIENT_NAME_TAKEN;
     }
 
-    private void saveIngredient(Ingredient toSave) {
-        assert getStorageSource() != null;
-
-        getStorageSource().getSaver().updateIngredients(Collections.singletonList(toSave));
+    @Override
+    protected String getEntityName(Ingredient entity) {
+        return entity.getName();
     }
 
-    private void finishExecutingSuccessfulIngredientCreation(Ingredient created) {
-        setCreatedIngredient(created);
-        setExecutionMessage(OK_INGREDIENT_CREATED);
-        beSuccessful();
-        finishExecuting();
+    @Override
+    protected String getEntityClassName() {
+        return Ingredient.class.toString();
+    }
+
+    @Override
+    protected void updateEntities(EntitySaver saver, Collection<Ingredient> entities) {
+        saver.updateIngredients(entities);
+    }
+
+    @Override
+    protected boolean entityNameExists(EntityLoader loader, String entityName) {
+        return loader.ingredientNameExists(entityName);
     }
 }

--- a/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
@@ -7,7 +7,7 @@ import com.recipecart.storage.EntitySaver;
 import java.util.Collection;
 
 /** This class represents an action item for the use case of a new ingredient being created. */
-public class CreateIngredientCommand extends SimpleCreateEntityCommand<Ingredient> {
+public final class CreateIngredientCommand extends SimpleCreateEntityCommand<Ingredient> {
     public static final String OK_INGREDIENT_CREATED = "Ingredient creation successful",
             NOT_OK_INVALID_INGREDIENT =
                     "Ingredient creation unsuccessful: the ingredient was invalid or null",

--- a/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
@@ -6,6 +6,7 @@ import com.recipecart.storage.EntityLoader;
 import com.recipecart.storage.EntitySaver;
 import java.util.Collection;
 
+/** This class represents an action item for the use case of a new ingredient being created. */
 public class CreateIngredientCommand extends SimpleCreateEntityCommand<Ingredient> {
     public static final String OK_INGREDIENT_CREATED = "Ingredient creation successful",
             NOT_OK_INVALID_INGREDIENT =
@@ -13,10 +14,22 @@ public class CreateIngredientCommand extends SimpleCreateEntityCommand<Ingredien
             NOT_OK_INGREDIENT_NAME_TAKEN =
                     "Ingredient creation unsuccessful: the ingredient name is already taken";
 
+    /**
+     * Creates the action item for creating an Ingredient and saving it into a given EntityStorage.
+     *
+     * @param toAdd the Ingredient to add
+     */
     public CreateIngredientCommand(Ingredient toAdd) {
         super(toAdd);
     }
 
+    /**
+     * Creates the action item for creating an Ingredient and saving it into a given EntityStorage.
+     *
+     * @param ingredientName the name of the ingredient to add
+     * @param units the units this ingredient uses
+     * @param imageUri URI of an image of this ingredient
+     */
     public CreateIngredientCommand(String ingredientName, String units, String imageUri) {
         this(new Ingredient(ingredientName, units, imageUri));
     }

--- a/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateIngredientCommand.java
@@ -1,0 +1,137 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.entities.Ingredient;
+import java.util.Collections;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CreateIngredientCommand extends EntityCommand {
+    public static final String OK_INGREDIENT_CREATED = "Ingredient creation successful",
+            NOT_OK_INVALID_INGREDIENT =
+                    "Ingredient creation unsuccessful: the ingredient was invalid or null",
+            NOT_OK_INGREDIENT_NAME_TAKEN =
+                    "Ingredient creation unsuccessful: the ingredient name is already taken";
+
+    private final Ingredient toAdd;
+    private Ingredient createdIngredient;
+
+    /**
+     * Creates an action item for a new Ingredient to be created and saved into the EntityStorage
+     * given to this command.
+     *
+     * @param toAdd the Ingredient to save
+     */
+    public CreateIngredientCommand(Ingredient toAdd) {
+        this.toAdd = toAdd;
+    }
+
+    /**
+     * Creates an action item for a new Ingredient to be created and saved into the EntityStorage
+     * given to this command.
+     *
+     * @param ingredientName the new, unique name of the Ingredient to save
+     * @param units the units of the Ingredient to save
+     * @param imageUri the URI of an image of the Ingredient to save
+     */
+    public CreateIngredientCommand(String ingredientName, String units, String imageUri) {
+        this(new Ingredient(ingredientName, units, imageUri));
+    }
+
+    /**
+     * Returns the (output) Ingredient that was created/saved when executing this command.
+     *
+     * @throws IllegalStateException if this command instance hasn't finished executing yet.
+     * @return the (non-null) Ingredient that was created/saved, if the command successfully added
+     *     it; null otherwise.
+     */
+    @Nullable public Ingredient getCreatedIngredient() {
+        if (!isFinishedExecuting()) {
+            throw new IllegalStateException("Command hasn't finished executing yet");
+        }
+        return createdIngredient;
+    }
+
+    private void setCreatedIngredient(@NotNull Ingredient createdIngredient) {
+        if (isFinishedExecuting()) {
+            throw new IllegalStateException(
+                    "Cannot set the created tag after command has executed");
+        }
+        if (this.createdIngredient != null) {
+            throw new IllegalStateException("Can only set created tag once");
+        }
+        Objects.requireNonNull(createdIngredient);
+        this.createdIngredient = createdIngredient;
+    }
+
+    public Ingredient getToAdd() {
+        return toAdd;
+    }
+
+    @Override
+    protected String getInvalidCommandMessage() {
+        String baseMessage = super.getInvalidCommandMessage();
+        if (baseMessage != null) {
+            return baseMessage;
+        }
+        if (!isIngredientValid()) {
+            return NOT_OK_INVALID_INGREDIENT;
+        }
+        try {
+            if (!isIngredientNameAvailable()) {
+                return NOT_OK_INGREDIENT_NAME_TAKEN;
+            }
+        } catch (RuntimeException e) { // for data access layer failures
+            e.printStackTrace();
+            return NOT_OK_ERROR;
+        }
+        return null;
+    }
+
+    private boolean isIngredientValid() {
+        return getToAdd() != null && getToAdd().getName() != null;
+    }
+
+    private boolean isIngredientNameAvailable() {
+        assert getStorageSource() != null;
+        assert getToAdd().getName() != null;
+        return !getStorageSource().getLoader().ingredientNameExists(getToAdd().getName());
+    }
+
+    /**
+     * Has the Ingredient be (created and) saved. If the ingredient name is null or corresponds to
+     * an already-existing ingredient, then this command's execution will be unsuccessful.
+     *
+     * @throws IllegalStateException if this method has been called before on this command instance.
+     */
+    @Override
+    public void execute() {
+        checkExecutionAlreadyDone();
+        if (finishInvalidCommand()) {
+            return;
+        }
+
+        try {
+            saveIngredient(getToAdd());
+        } catch (RuntimeException e) {
+            finishExecutingFromError(e);
+            return;
+        }
+
+        finishExecutingSuccessfulIngredientCreation(getToAdd());
+    }
+
+    private void saveIngredient(Ingredient toSave) {
+        assert getStorageSource() != null;
+
+        getStorageSource().getSaver().updateIngredients(Collections.singletonList(toSave));
+    }
+
+    private void finishExecutingSuccessfulIngredientCreation(Ingredient created) {
+        setCreatedIngredient(created);
+        setExecutionMessage(OK_INGREDIENT_CREATED);
+        beSuccessful();
+        finishExecuting();
+    }
+}

--- a/src/main/java/com/recipecart/usecases/CreateRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateRecipeCommand.java
@@ -254,7 +254,7 @@ public final class CreateRecipeCommand extends EntityCommand {
         tagCreation.setStorageSource(getStorageSource());
         tagCreation.execute();
 
-        return tagCreation.getCreatedTag();
+        return tagCreation.getCreatedEntity();
     }
 
     private Recipe createRecipeFromForm() throws IOException {

--- a/src/main/java/com/recipecart/usecases/CreateRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateRecipeCommand.java
@@ -111,11 +111,11 @@ public final class CreateRecipeCommand extends EntityCommand {
         if (baseMessage != null) {
             return baseMessage;
         }
+        if (!isRecipeToAddValid()) {
+            return NOT_OK_INVALID_RECIPE;
+        }
         try {
-            if (!isRecipeToAddValid()) {
-                return NOT_OK_INVALID_RECIPE;
-            }
-            if (!doIngredientsExist()) {
+            if (!doIngredientsExist() || !doesAuthorExist()) {
                 return NOT_OK_RECIPE_RESOURCES_NOT_FOUND;
             }
             if (!isRecipeNameAvailable()) {
@@ -160,8 +160,12 @@ public final class CreateRecipeCommand extends EntityCommand {
 
     private boolean isAuthorUsernameValid() {
         assert getStorageSource() != null;
-        return getToAdd().getAuthorUsername() != null
-                && getStorageSource().getLoader().usernameExists(getToAdd().getAuthorUsername());
+        return getToAdd().getAuthorUsername() != null;
+    }
+
+    private boolean doesAuthorExist() {
+        assert getStorageSource() != null;
+        return getStorageSource().getLoader().usernameExists(getToAdd().getAuthorUsername());
     }
 
     private boolean isRecipeNameAvailable() {

--- a/src/main/java/com/recipecart/usecases/CreateRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateRecipeCommand.java
@@ -12,7 +12,7 @@ import java.util.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/** This class represents an action item for the use case for a user creating a new Recipe. */
+/** This class represents an action item for the use case for a user creating a new recipe. */
 public final class CreateRecipeCommand extends EntityCommand {
     public static final String
             OK_RECIPE_CREATED_WITH_GIVEN_NAME =
@@ -34,7 +34,8 @@ public final class CreateRecipeCommand extends EntityCommand {
     private Set<Tag> createdTags = null;
 
     /**
-     * Creates an action item for a user to create a Recipe.
+     * Creates an action item for a user to create a Recipe, and for that Recipe to be saved into a
+     * given EntityStorage.
      *
      * @param recipeToAdd the Recipe that the user creates
      */

--- a/src/main/java/com/recipecart/usecases/CreateTagCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateTagCommand.java
@@ -6,16 +6,26 @@ import com.recipecart.storage.EntityLoader;
 import com.recipecart.storage.EntitySaver;
 import java.util.Collection;
 
-/** This class represents an action item for the use case of a new Tag being created. */
+/** This class represents an action item for the use case of a new tag being created. */
 public final class CreateTagCommand extends SimpleCreateEntityCommand<Tag> {
     public static final String OK_TAG_CREATED = "Tag creation successful",
             NOT_OK_INVALID_TAG = "Tag creation unsuccessful: the tag was invalid or null",
             NOT_OK_TAG_NAME_TAKEN = "Tag creation unsuccessful: the tag name is already taken";
 
+    /**
+     * Creates the action item for creating a Tag and saving it into a given EntityStorage.
+     *
+     * @param toAdd the Tag to add
+     */
     public CreateTagCommand(Tag toAdd) {
         super(toAdd);
     }
 
+    /**
+     * Creates the action item for creating a Tag and saving it into a given EntityStorage.
+     *
+     * @param tagName the name of the Tag to add
+     */
     public CreateTagCommand(String tagName) {
         this(new Tag(tagName));
     }

--- a/src/main/java/com/recipecart/usecases/CreateTagCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateTagCommand.java
@@ -1,0 +1,134 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.entities.Tag;
+import java.util.Collections;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** This class represents an action item for the use case of a new Tag being created. */
+public class CreateTagCommand extends EntityCommand {
+    public static final String OK_TAG_CREATED = "Tag creation successful",
+            NOT_OK_INVALID_TAG = "Tag creation unsuccessful: the tag was invalid or null",
+            NOT_OK_TAG_NAME_TAKEN = "Tag creation unsuccessful: the tag name is already taken";
+
+    private final Tag toAdd;
+    private Tag createdTag = null;
+
+    /**
+     * Creates an action item for a new Tag to be created and saved into the EntityStorage given to
+     * this command.
+     *
+     * @param toAdd the Tag to add
+     */
+    public CreateTagCommand(Tag toAdd) {
+        this.toAdd = toAdd;
+    }
+
+    /**
+     * Creates an action item for a new Tag to be created and saved into the EntityStorage given to
+     * this command.
+     *
+     * @param tagName the name of the Tag to add
+     */
+    public CreateTagCommand(String tagName) {
+        this(new Tag(tagName));
+    }
+
+    /**
+     * Returns the (output) Tag that was created and saved when executing this command.
+     *
+     * @throws IllegalStateException if this command instance hasn't finished executing yet.
+     * @return the (non-null) Tag that was created/saved, if the command successfully added it; null
+     *     otherwise.
+     */
+    @Nullable public Tag getCreatedTag() {
+        if (!isFinishedExecuting()) {
+            throw new IllegalStateException("Command hasn't finished executing yet");
+        }
+        return createdTag;
+    }
+
+    private void setCreatedTag(@NotNull Tag createdTag) {
+        if (isFinishedExecuting()) {
+            throw new IllegalStateException(
+                    "Cannot set the created tag after command has executed");
+        }
+        if (this.createdTag != null) {
+            throw new IllegalStateException("Can only set created tag once");
+        }
+        Objects.requireNonNull(createdTag);
+        this.createdTag = createdTag;
+    }
+
+    public Tag getToAdd() {
+        return toAdd;
+    }
+
+    @Override
+    protected String getInvalidCommandMessage() {
+        String baseMessage = super.getInvalidCommandMessage();
+        if (baseMessage != null) {
+            return baseMessage;
+        }
+        if (!isTagValid()) {
+            return NOT_OK_INVALID_TAG;
+        }
+        try {
+            if (!isTagNameAvailable()) {
+                return NOT_OK_TAG_NAME_TAKEN;
+            }
+        } catch (RuntimeException e) { // for data access layer failures
+            e.printStackTrace();
+            return NOT_OK_ERROR;
+        }
+        return null;
+    }
+
+    private boolean isTagValid() {
+        return getToAdd() != null && getToAdd().getName() != null;
+    }
+
+    private boolean isTagNameAvailable() {
+        assert getStorageSource() != null;
+        assert getToAdd().getName() != null;
+        return !getStorageSource().getLoader().tagNameExists(getToAdd().getName());
+    }
+
+    /**
+     * Has the Tag be created and saved. If the tag name is null or corresponds to an
+     * already-existing tag, then this command's execution will be unsuccessful.
+     *
+     * @throws IllegalStateException if this method has been called before on this command instance.
+     */
+    @Override
+    public void execute() {
+        checkExecutionAlreadyDone();
+        if (finishInvalidCommand()) {
+            return;
+        }
+
+        try {
+            saveTag(getToAdd());
+        } catch (RuntimeException e) {
+            finishExecutingFromError(e);
+            return;
+        }
+
+        finishExecutingSuccessfulTag(getToAdd());
+    }
+
+    private void saveTag(Tag toSave) {
+        assert getStorageSource() != null;
+
+        getStorageSource().getSaver().updateTags(Collections.singletonList(toSave));
+    }
+
+    private void finishExecutingSuccessfulTag(Tag created) {
+        setCreatedTag(created);
+        setExecutionMessage(OK_TAG_CREATED);
+        beSuccessful();
+        finishExecuting();
+    }
+}

--- a/src/main/java/com/recipecart/usecases/CreateTagCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateTagCommand.java
@@ -2,133 +2,56 @@
 package com.recipecart.usecases;
 
 import com.recipecart.entities.Tag;
-import java.util.Collections;
-import java.util.Objects;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.recipecart.storage.EntityLoader;
+import com.recipecart.storage.EntitySaver;
+import java.util.Collection;
 
 /** This class represents an action item for the use case of a new Tag being created. */
-public class CreateTagCommand extends EntityCommand {
+public final class CreateTagCommand extends SimpleCreateEntityCommand<Tag> {
     public static final String OK_TAG_CREATED = "Tag creation successful",
             NOT_OK_INVALID_TAG = "Tag creation unsuccessful: the tag was invalid or null",
             NOT_OK_TAG_NAME_TAKEN = "Tag creation unsuccessful: the tag name is already taken";
 
-    private final Tag toAdd;
-    private Tag createdTag = null;
-
-    /**
-     * Creates an action item for a new Tag to be created and saved into the EntityStorage given to
-     * this command.
-     *
-     * @param toAdd the Tag to add
-     */
     public CreateTagCommand(Tag toAdd) {
-        this.toAdd = toAdd;
+        super(toAdd);
     }
 
-    /**
-     * Creates an action item for a new Tag to be created and saved into the EntityStorage given to
-     * this command.
-     *
-     * @param tagName the name of the Tag to add
-     */
     public CreateTagCommand(String tagName) {
         this(new Tag(tagName));
     }
 
-    /**
-     * Returns the (output) Tag that was created and saved when executing this command.
-     *
-     * @throws IllegalStateException if this command instance hasn't finished executing yet.
-     * @return the (non-null) Tag that was created/saved, if the command successfully added it; null
-     *     otherwise.
-     */
-    @Nullable public Tag getCreatedTag() {
-        if (!isFinishedExecuting()) {
-            throw new IllegalStateException("Command hasn't finished executing yet");
-        }
-        return createdTag;
-    }
-
-    private void setCreatedTag(@NotNull Tag createdTag) {
-        if (isFinishedExecuting()) {
-            throw new IllegalStateException(
-                    "Cannot set the created tag after command has executed");
-        }
-        if (this.createdTag != null) {
-            throw new IllegalStateException("Can only set created tag once");
-        }
-        Objects.requireNonNull(createdTag);
-        this.createdTag = createdTag;
-    }
-
-    public Tag getToAdd() {
-        return toAdd;
+    @Override
+    protected String getOkEntityCreatedMessage() {
+        return OK_TAG_CREATED;
     }
 
     @Override
-    protected String getInvalidCommandMessage() {
-        String baseMessage = super.getInvalidCommandMessage();
-        if (baseMessage != null) {
-            return baseMessage;
-        }
-        if (!isTagValid()) {
-            return NOT_OK_INVALID_TAG;
-        }
-        try {
-            if (!isTagNameAvailable()) {
-                return NOT_OK_TAG_NAME_TAKEN;
-            }
-        } catch (RuntimeException e) { // for data access layer failures
-            e.printStackTrace();
-            return NOT_OK_ERROR;
-        }
-        return null;
+    protected String getNotOkInvalidEntityMessage() {
+        return NOT_OK_INVALID_TAG;
     }
 
-    private boolean isTagValid() {
-        return getToAdd() != null && getToAdd().getName() != null;
-    }
-
-    private boolean isTagNameAvailable() {
-        assert getStorageSource() != null;
-        assert getToAdd().getName() != null;
-        return !getStorageSource().getLoader().tagNameExists(getToAdd().getName());
-    }
-
-    /**
-     * Has the Tag be created and saved. If the tag name is null or corresponds to an
-     * already-existing tag, then this command's execution will be unsuccessful.
-     *
-     * @throws IllegalStateException if this method has been called before on this command instance.
-     */
     @Override
-    public void execute() {
-        checkExecutionAlreadyDone();
-        if (finishInvalidCommand()) {
-            return;
-        }
-
-        try {
-            saveTag(getToAdd());
-        } catch (RuntimeException e) {
-            finishExecutingFromError(e);
-            return;
-        }
-
-        finishExecutingSuccessfulTag(getToAdd());
+    protected String getNotOkEntityNameAlreadyTakenMessage() {
+        return NOT_OK_TAG_NAME_TAKEN;
     }
 
-    private void saveTag(Tag toSave) {
-        assert getStorageSource() != null;
-
-        getStorageSource().getSaver().updateTags(Collections.singletonList(toSave));
+    @Override
+    protected String getEntityName(Tag entity) {
+        return entity.getName();
     }
 
-    private void finishExecutingSuccessfulTag(Tag created) {
-        setCreatedTag(created);
-        setExecutionMessage(OK_TAG_CREATED);
-        beSuccessful();
-        finishExecuting();
+    @Override
+    protected String getEntityClassName() {
+        return Tag.class.toString();
+    }
+
+    @Override
+    protected void updateEntities(EntitySaver saver, Collection<Tag> entities) {
+        saver.updateTags(entities);
+    }
+
+    @Override
+    protected boolean entityNameExists(EntityLoader loader, String entityName) {
+        return loader.tagNameExists(entityName);
     }
 }

--- a/src/main/java/com/recipecart/usecases/CreateUserCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateUserCommand.java
@@ -6,11 +6,19 @@ import com.recipecart.storage.EntityLoader;
 import com.recipecart.storage.EntitySaver;
 import java.util.Collection;
 
+/** This class represents an action item for the use case of a new user being created. */
 public class CreateUserCommand extends SimpleCreateEntityCommand<User> {
     public static final String OK_USER_CREATED = "User creation successful",
             NOT_OK_INVALID_USER = "User creation unsuccessful: the user was invalid or null",
             NOT_OK_USERNAME_TAKEN = "User creation unsuccessful: the username is already taken";
 
+    /**
+     * Creates the action item for creating a new User and saving it into a given EntityStorage.
+     * This user starts off with nothing (i.e. no saved recipes, etc.).
+     *
+     * @param username the username of the user to create
+     * @param emailAddress an email address of the user to create
+     */
     public CreateUserCommand(String username, String emailAddress) {
         super(new User.Builder().setUsername(username).setEmailAddress(emailAddress).build());
     }

--- a/src/main/java/com/recipecart/usecases/CreateUserCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateUserCommand.java
@@ -1,0 +1,52 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntityLoader;
+import com.recipecart.storage.EntitySaver;
+import java.util.Collection;
+
+public class CreateUserCommand extends SimpleCreateEntityCommand<User> {
+    public static final String OK_USER_CREATED = "User creation successful",
+            NOT_OK_INVALID_USER = "User creation unsuccessful: the user was invalid or null",
+            NOT_OK_USERNAME_TAKEN = "User creation unsuccessful: the username is already taken";
+
+    protected CreateUserCommand(String username, String emailAddress) {
+        super(new User.Builder().setUsername(username).setEmailAddress(emailAddress).build());
+    }
+
+    @Override
+    protected String getOkEntityCreatedMessage() {
+        return OK_USER_CREATED;
+    }
+
+    @Override
+    protected String getNotOkInvalidEntityMessage() {
+        return NOT_OK_INVALID_USER;
+    }
+
+    @Override
+    protected String getNotOkEntityNameAlreadyTakenMessage() {
+        return NOT_OK_USERNAME_TAKEN;
+    }
+
+    @Override
+    protected String getEntityName(User entity) {
+        return entity.getUsername();
+    }
+
+    @Override
+    protected String getEntityClassName() {
+        return User.class.getName();
+    }
+
+    @Override
+    protected void updateEntities(EntitySaver saver, Collection<User> entities) {
+        saver.updateUsers(entities);
+    }
+
+    @Override
+    protected boolean entityNameExists(EntityLoader loader, String entityName) {
+        return loader.usernameExists(entityName);
+    }
+}

--- a/src/main/java/com/recipecart/usecases/CreateUserCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateUserCommand.java
@@ -7,7 +7,7 @@ import com.recipecart.storage.EntitySaver;
 import java.util.Collection;
 
 /** This class represents an action item for the use case of a new user being created. */
-public class CreateUserCommand extends SimpleCreateEntityCommand<User> {
+public final class CreateUserCommand extends SimpleCreateEntityCommand<User> {
     public static final String OK_USER_CREATED = "User creation successful",
             NOT_OK_INVALID_USER = "User creation unsuccessful: the user was invalid or null",
             NOT_OK_USERNAME_TAKEN = "User creation unsuccessful: the username is already taken";

--- a/src/main/java/com/recipecart/usecases/CreateUserCommand.java
+++ b/src/main/java/com/recipecart/usecases/CreateUserCommand.java
@@ -11,7 +11,7 @@ public class CreateUserCommand extends SimpleCreateEntityCommand<User> {
             NOT_OK_INVALID_USER = "User creation unsuccessful: the user was invalid or null",
             NOT_OK_USERNAME_TAKEN = "User creation unsuccessful: the username is already taken";
 
-    protected CreateUserCommand(String username, String emailAddress) {
+    public CreateUserCommand(String username, String emailAddress) {
         super(new User.Builder().setUsername(username).setEmailAddress(emailAddress).build());
     }
 

--- a/src/main/java/com/recipecart/usecases/EntityCommand.java
+++ b/src/main/java/com/recipecart/usecases/EntityCommand.java
@@ -151,9 +151,15 @@ public abstract class EntityCommand implements Command {
     }
 
     protected void finishExecutingFromError(Exception e) {
-        e.printStackTrace();
+        if (e != null) {
+            e.printStackTrace();
+        }
         setExecutionMessage(NOT_OK_ERROR);
         finishExecuting();
+    }
+
+    protected void finishExecutingFromError() {
+        finishExecutingFromError(null);
     }
 
     protected void finishExecutingImpossibleOutcome(Exception e) {

--- a/src/main/java/com/recipecart/usecases/GetIngredientCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetIngredientCommand.java
@@ -21,7 +21,7 @@ public final class GetIngredientCommand extends SimpleGetCommand<Ingredient> {
      *
      * @param name the name of the ingredient to retrieve.
      */
-    GetIngredientCommand(String name) {
+    public GetIngredientCommand(String name) {
         super(name);
     }
 

--- a/src/main/java/com/recipecart/usecases/GetIngredientCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetIngredientCommand.java
@@ -1,0 +1,52 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.entities.Ingredient;
+import com.recipecart.storage.EntityLoader;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * This class represents the action item for the use case of retrieving a ingredient from a given
+ * EntityStorage.
+ */
+public class GetIngredientCommand extends SimpleGetCommand<Ingredient> {
+    public static final String OK_INGREDIENT_RETRIEVED = "Ingredient retrieval successful",
+            NOT_OK_INGREDIENT_NOT_FOUND =
+                    "Ingredient retrieval unsuccessful: a ingredient with the given name could not"
+                            + " be found";
+
+    /**
+     * Creates the action item for retrieving an ingredient with the given name.
+     *
+     * @param name the name of the ingredient to retrieve.
+     */
+    GetIngredientCommand(String name) {
+        super(name);
+    }
+
+    @Override
+    protected String getOkEntityRetrievedMessage() {
+        return OK_INGREDIENT_RETRIEVED;
+    }
+
+    @Override
+    protected String getNotOkNotFoundMessage() {
+        return NOT_OK_INGREDIENT_NOT_FOUND;
+    }
+
+    @Override
+    protected String getEntityClassName() {
+        return Ingredient.class.getName();
+    }
+
+    @Override
+    protected boolean entityNameExists(EntityLoader loader, String entityName) {
+        return loader.ingredientNameExists(entityName);
+    }
+
+    @Override
+    protected Ingredient retrieveEntity(EntityLoader loader, String entityName) throws IOException {
+        return loader.getIngredientsByNames(Collections.singletonList(entityName)).get(0);
+    }
+}

--- a/src/main/java/com/recipecart/usecases/GetIngredientCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetIngredientCommand.java
@@ -10,7 +10,7 @@ import java.util.Collections;
  * This class represents the action item for the use case of retrieving a ingredient from a given
  * EntityStorage.
  */
-public class GetIngredientCommand extends SimpleGetCommand<Ingredient> {
+public final class GetIngredientCommand extends SimpleGetCommand<Ingredient> {
     public static final String OK_INGREDIENT_RETRIEVED = "Ingredient retrieval successful",
             NOT_OK_INGREDIENT_NOT_FOUND =
                     "Ingredient retrieval unsuccessful: a ingredient with the given name could not"

--- a/src/main/java/com/recipecart/usecases/GetRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetRecipeCommand.java
@@ -10,7 +10,7 @@ import java.util.Collections;
  * This class represents the action item for the use case of retrieving a recipe from a given
  * EntityStorage.
  */
-public class GetRecipeCommand extends SimpleGetCommand<Recipe> {
+public final class GetRecipeCommand extends SimpleGetCommand<Recipe> {
     public static final String OK_RECIPE_RETRIEVED = "Recipe retrieval successful",
             NOT_OK_RECIPE_NOT_FOUND =
                     "Recipe retrieval unsuccessful: a recipe with the given name could not be"

--- a/src/main/java/com/recipecart/usecases/GetRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetRecipeCommand.java
@@ -1,0 +1,52 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.entities.Recipe;
+import com.recipecart.storage.EntityLoader;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * This class represents the action item for the use case of retrieving a recipe from a given
+ * EntityStorage.
+ */
+public class GetRecipeCommand extends SimpleGetCommand<Recipe> {
+    public static final String OK_RECIPE_RETRIEVED = "Recipe retrieval successful",
+            NOT_OK_RECIPE_NOT_FOUND =
+                    "Recipe retrieval unsuccessful: a recipe with the given name could not be"
+                            + " found";
+
+    /**
+     * Creates the action item for retrieving a recipe with the given name.
+     *
+     * @param name the name of the recipe to retrieve.
+     */
+    GetRecipeCommand(String name) {
+        super(name);
+    }
+
+    @Override
+    protected String getOkEntityRetrievedMessage() {
+        return OK_RECIPE_RETRIEVED;
+    }
+
+    @Override
+    protected String getNotOkNotFoundMessage() {
+        return NOT_OK_RECIPE_NOT_FOUND;
+    }
+
+    @Override
+    protected String getEntityClassName() {
+        return Recipe.class.getName();
+    }
+
+    @Override
+    protected boolean entityNameExists(EntityLoader loader, String entityName) {
+        return loader.recipeNameExists(entityName);
+    }
+
+    @Override
+    protected Recipe retrieveEntity(EntityLoader loader, String entityName) throws IOException {
+        return loader.getRecipesByNames(Collections.singletonList(entityName)).get(0);
+    }
+}

--- a/src/main/java/com/recipecart/usecases/GetRecipeCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetRecipeCommand.java
@@ -21,7 +21,7 @@ public final class GetRecipeCommand extends SimpleGetCommand<Recipe> {
      *
      * @param name the name of the recipe to retrieve.
      */
-    GetRecipeCommand(String name) {
+    public GetRecipeCommand(String name) {
         super(name);
     }
 

--- a/src/main/java/com/recipecart/usecases/GetTagCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetTagCommand.java
@@ -1,0 +1,51 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.entities.Tag;
+import com.recipecart.storage.EntityLoader;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * This class represents the action item for the use case of retrieving a tag from a given
+ * EntityStorage.
+ */
+public class GetTagCommand extends SimpleGetCommand<Tag> {
+    public static final String OK_TAG_RETRIEVED = "Tag retrieval successful",
+            NOT_OK_TAG_NOT_FOUND =
+                    "Tag retrieval unsuccessful: a tag with the given name could not be found";
+
+    /**
+     * Creates the action item for retrieving a tag with the given name.
+     *
+     * @param name the name of the tag to retrieve.
+     */
+    GetTagCommand(String name) {
+        super(name);
+    }
+
+    @Override
+    protected String getOkEntityRetrievedMessage() {
+        return OK_TAG_RETRIEVED;
+    }
+
+    @Override
+    protected String getNotOkNotFoundMessage() {
+        return NOT_OK_TAG_NOT_FOUND;
+    }
+
+    @Override
+    protected String getEntityClassName() {
+        return Tag.class.getName();
+    }
+
+    @Override
+    protected boolean entityNameExists(EntityLoader loader, String entityName) {
+        return loader.tagNameExists(entityName);
+    }
+
+    @Override
+    protected Tag retrieveEntity(EntityLoader loader, String entityName) throws IOException {
+        return loader.getTagsByNames(Collections.singletonList(entityName)).get(0);
+    }
+}

--- a/src/main/java/com/recipecart/usecases/GetTagCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetTagCommand.java
@@ -20,7 +20,7 @@ public final class GetTagCommand extends SimpleGetCommand<Tag> {
      *
      * @param name the name of the tag to retrieve.
      */
-    GetTagCommand(String name) {
+    public GetTagCommand(String name) {
         super(name);
     }
 

--- a/src/main/java/com/recipecart/usecases/GetTagCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetTagCommand.java
@@ -10,7 +10,7 @@ import java.util.Collections;
  * This class represents the action item for the use case of retrieving a tag from a given
  * EntityStorage.
  */
-public class GetTagCommand extends SimpleGetCommand<Tag> {
+public final class GetTagCommand extends SimpleGetCommand<Tag> {
     public static final String OK_TAG_RETRIEVED = "Tag retrieval successful",
             NOT_OK_TAG_NOT_FOUND =
                     "Tag retrieval unsuccessful: a tag with the given name could not be found";

--- a/src/main/java/com/recipecart/usecases/GetUserCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetUserCommand.java
@@ -20,7 +20,7 @@ public final class GetUserCommand extends SimpleGetCommand<User> {
      *
      * @param name the name of the user to retrieve.
      */
-    GetUserCommand(String name) {
+    public GetUserCommand(String name) {
         super(name);
     }
 

--- a/src/main/java/com/recipecart/usecases/GetUserCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetUserCommand.java
@@ -1,0 +1,51 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntityLoader;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * This class represents the action item for the use case of retrieving a user from a given
+ * EntityStorage.
+ */
+public class GetUserCommand extends SimpleGetCommand<User> {
+    public static final String OK_USER_RETRIEVED = "User retrieval successful",
+            NOT_OK_USER_NOT_FOUND =
+                    "User retrieval unsuccessful: a user with the given name could not be found";
+
+    /**
+     * Creates the action item for retrieving a user with the given name.
+     *
+     * @param name the name of the user to retrieve.
+     */
+    GetUserCommand(String name) {
+        super(name);
+    }
+
+    @Override
+    protected String getOkEntityRetrievedMessage() {
+        return OK_USER_RETRIEVED;
+    }
+
+    @Override
+    protected String getNotOkNotFoundMessage() {
+        return NOT_OK_USER_NOT_FOUND;
+    }
+
+    @Override
+    protected String getEntityClassName() {
+        return User.class.getName();
+    }
+
+    @Override
+    protected boolean entityNameExists(EntityLoader loader, String entityName) {
+        return loader.usernameExists(entityName);
+    }
+
+    @Override
+    protected User retrieveEntity(EntityLoader loader, String entityName) throws IOException {
+        return loader.getUsersByNames(Collections.singletonList(entityName)).get(0);
+    }
+}

--- a/src/main/java/com/recipecart/usecases/GetUserCommand.java
+++ b/src/main/java/com/recipecart/usecases/GetUserCommand.java
@@ -10,7 +10,7 @@ import java.util.Collections;
  * This class represents the action item for the use case of retrieving a user from a given
  * EntityStorage.
  */
-public class GetUserCommand extends SimpleGetCommand<User> {
+public final class GetUserCommand extends SimpleGetCommand<User> {
     public static final String OK_USER_RETRIEVED = "User retrieval successful",
             NOT_OK_USER_NOT_FOUND =
                     "User retrieval unsuccessful: a user with the given name could not be found";

--- a/src/main/java/com/recipecart/usecases/SimpleCreateEntityCommand.java
+++ b/src/main/java/com/recipecart/usecases/SimpleCreateEntityCommand.java
@@ -19,6 +19,12 @@ public abstract class SimpleCreateEntityCommand<T> extends EntityCommand {
     private final T toAdd;
     private T createdEntity = null;
 
+    /**
+     * Creates the action item of saving the given entity to the EntityStorage inputted into this
+     * command.
+     *
+     * @param toAdd the entity to save
+     */
     protected SimpleCreateEntityCommand(T toAdd) {
         this.toAdd = toAdd;
     }

--- a/src/main/java/com/recipecart/usecases/SimpleCreateEntityCommand.java
+++ b/src/main/java/com/recipecart/usecases/SimpleCreateEntityCommand.java
@@ -1,0 +1,138 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.storage.EntityLoader;
+import com.recipecart.storage.EntitySaver;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class represents the action item of a new entity of type T being created/saved into a given
+ * EntityStorage.
+ *
+ * @param <T> the type of the entity (e.g. Tag, Ingredient, User) to be created/saved
+ */
+public abstract class SimpleCreateEntityCommand<T> extends EntityCommand {
+    private final T toAdd;
+    private T createdEntity = null;
+
+    protected SimpleCreateEntityCommand(T toAdd) {
+        this.toAdd = toAdd;
+    }
+
+    /**
+     * Returns the (output) T that was created and saved when executing this command.
+     *
+     * @throws IllegalStateException if this command instance hasn't finished executing yet.
+     * @return the (non-null) T that was created/saved, if the command successfully added it; null
+     *     otherwise.
+     */
+    @Nullable public T getCreatedEntity() {
+        if (!isFinishedExecuting()) {
+            throw new IllegalStateException("Command hasn't finished executing yet");
+        }
+        return createdEntity;
+    }
+
+    private void setCreatedEntity(@NotNull T createdEntity) {
+        if (isFinishedExecuting()) {
+            throw new IllegalStateException(
+                    "Cannot set the created "
+                            + getEntityClassName()
+                            + "after command has executed");
+        }
+        if (this.createdEntity != null) {
+            throw new IllegalStateException(
+                    "Can only set created " + getEntityClassName() + " once");
+        }
+        Objects.requireNonNull(createdEntity);
+        this.createdEntity = createdEntity;
+    }
+
+    public T getEntityToAdd() {
+        return toAdd;
+    }
+
+    @Override
+    protected String getInvalidCommandMessage() {
+        String baseMessage = super.getInvalidCommandMessage();
+        if (baseMessage != null) {
+            return baseMessage;
+        }
+        if (!isEntityValid()) {
+            return getNotOkInvalidEntityMessage();
+        }
+        try {
+            if (!isEntityNameAvailable()) {
+                return getNotOkEntityNameAlreadyTakenMessage();
+            }
+        } catch (RuntimeException e) { // for data access layer failures
+            e.printStackTrace();
+            return NOT_OK_ERROR;
+        }
+        return null;
+    }
+
+    private boolean isEntityValid() {
+        return getEntityToAdd() != null && getEntityName(getEntityToAdd()) != null;
+    }
+
+    private boolean isEntityNameAvailable() {
+        assert getStorageSource() != null;
+        assert getEntityName(getEntityToAdd()) != null;
+        return !entityNameExists(getStorageSource().getLoader(), getEntityName(getEntityToAdd()));
+    }
+
+    /**
+     * Has the entity (T) be created and saved. If the entity name is null or corresponds to an
+     * already-existing entity of the same type, then this command's execution will be unsuccessful.
+     *
+     * @throws IllegalStateException if this method has been called before on this command instance.
+     */
+    @Override
+    public void execute() {
+        checkExecutionAlreadyDone();
+        if (finishInvalidCommand()) {
+            return;
+        }
+
+        try {
+            saveEntity(getEntityToAdd());
+        } catch (RuntimeException e) {
+            finishExecutingFromError(e);
+            return;
+        }
+
+        finishExecutingSuccessfulEntityCreation(getEntityToAdd());
+    }
+
+    private void saveEntity(T toSave) {
+        assert getStorageSource() != null;
+
+        updateEntities(getStorageSource().getSaver(), Collections.singletonList(toSave));
+    }
+
+    private void finishExecutingSuccessfulEntityCreation(T created) {
+        setCreatedEntity(created);
+        setExecutionMessage(getOkEntityCreatedMessage());
+        beSuccessful();
+        finishExecuting();
+    }
+
+    protected abstract String getOkEntityCreatedMessage();
+
+    protected abstract String getNotOkInvalidEntityMessage();
+
+    protected abstract String getNotOkEntityNameAlreadyTakenMessage();
+
+    protected abstract String getEntityName(T entity);
+
+    protected abstract String getEntityClassName();
+
+    protected abstract void updateEntities(EntitySaver saver, Collection<T> entities);
+
+    protected abstract boolean entityNameExists(EntityLoader loader, String entityName);
+}

--- a/src/main/java/com/recipecart/usecases/SimpleGetCommand.java
+++ b/src/main/java/com/recipecart/usecases/SimpleGetCommand.java
@@ -1,0 +1,133 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import com.recipecart.storage.EntityLoader;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * This class represents the action item of an entity, of type T, with the given name, being
+ * retrieved from a given EntityStorage.
+ *
+ * @param <T> the type of the entity (e.g. Tag, Ingredient, User, Recipe) to be retrieved
+ */
+public abstract class SimpleGetCommand<T> extends EntityCommand {
+    private T retrievedEntity;
+    private final String name;
+
+    /**
+     * Creates the action item of retrieving the entity, of type T, with the given name.
+     *
+     * @param name the name of the T entity to retrieve
+     */
+    SimpleGetCommand(String name) {
+        this.name = name;
+    }
+
+    public String getEntityName() {
+        return name;
+    }
+
+    /**
+     * Returns the (output) T that was retrieved when executing this command.
+     *
+     * @throws IllegalStateException if this command instance hasn't finished executing yet.
+     * @return the (non-null) T that was retrieved, if the command successfully retrieved it; null
+     *     otherwise.
+     */
+    public T getRetrievedEntity() {
+        if (!isFinishedExecuting()) {
+            throw new IllegalStateException("Command hasn't finished executing yet");
+        }
+        return retrievedEntity;
+    }
+
+    private void setRetrievedEntity(T retrievedEntity) {
+        if (isFinishedExecuting()) {
+            throw new IllegalStateException(
+                    "Cannot set the retrieved "
+                            + getEntityClassName()
+                            + "after command has executed");
+        }
+        if (this.retrievedEntity != null) {
+            throw new IllegalStateException(
+                    "Can only set retrieved " + getEntityClassName() + " once");
+        }
+        Objects.requireNonNull(retrievedEntity);
+        this.retrievedEntity = retrievedEntity;
+    }
+
+    @Override
+    protected String getInvalidCommandMessage() {
+        String baseMessage = super.getInvalidCommandMessage();
+        if (baseMessage != null) {
+            return baseMessage;
+        }
+        if (!isNameValid()) {
+            return getNotOkNotFoundMessage();
+        }
+        try {
+            if (!doesEntityExist()) {
+                return getNotOkNotFoundMessage();
+            }
+        } catch (RuntimeException e) { // for data access layer failures
+            e.printStackTrace();
+            return NOT_OK_ERROR;
+        }
+        return null;
+    }
+
+    private boolean isNameValid() {
+        return getEntityName() != null;
+    }
+
+    private boolean doesEntityExist() {
+        assert getStorageSource() != null;
+        return entityNameExists(getStorageSource().getLoader(), getEntityName());
+    }
+
+    /**
+     * Has the entity (T) be created and saved. If the entity name is null or corresponds to an
+     * already-existing entity of the same type, then this command's execution will be unsuccessful.
+     *
+     * @throws IllegalStateException if this method has been called before on this command instance.
+     */
+    @Override
+    public void execute() {
+        checkExecutionAlreadyDone();
+        if (finishInvalidCommand()) {
+            return;
+        }
+
+        T retrieved;
+        try {
+            assert getStorageSource() != null;
+            retrieved = retrieveEntity(getStorageSource().getLoader(), getEntityName());
+        } catch (RuntimeException e) {
+            finishExecutingFromError(e);
+            return;
+        } catch (IOException e) {
+            finishExecutingImpossibleOutcome(e);
+            return;
+        }
+
+        finishExecutingSuccessfulEntityCreation(retrieved);
+    }
+
+    private void finishExecutingSuccessfulEntityCreation(T retrieved) {
+        setRetrievedEntity(retrieved);
+        setExecutionMessage(getOkEntityRetrievedMessage());
+        beSuccessful();
+        finishExecuting();
+    }
+
+    protected abstract String getOkEntityRetrievedMessage();
+
+    protected abstract String getNotOkNotFoundMessage();
+
+    protected abstract String getEntityClassName();
+
+    protected abstract boolean entityNameExists(EntityLoader loader, String entityName);
+
+    protected abstract T retrieveEntity(EntityLoader loader, String entityName) throws IOException;
+}

--- a/src/main/java/com/recipecart/utils/RecipeForm.java
+++ b/src/main/java/com/recipecart/utils/RecipeForm.java
@@ -112,7 +112,7 @@ public final class RecipeForm {
         return Utils.allowNull(directions, Collections::unmodifiableList);
     }
 
-    @Nullable public Set<String> getTags() {
+    @Nullable public Set<String> getTagNames() {
         return Utils.allowNull(tags, Collections::unmodifiableSet);
     }
 

--- a/src/main/java/com/recipecart/utils/RecipeForm.java
+++ b/src/main/java/com/recipecart/utils/RecipeForm.java
@@ -31,18 +31,19 @@ public final class RecipeForm {
      * @param recipe the recipe whose fields to copy
      */
     public RecipeForm(Recipe recipe) {
-        this.name = recipe.getName();
-        this.presentationName = recipe.getPresentationName();
-        this.authorUsername = recipe.getAuthorUsername();
-        this.prepTime = recipe.getPrepTime();
-        this.cookTime = recipe.getCookTime();
-        this.imageUri = recipe.getImageUri();
-        this.numServings = recipe.getNumServings();
-        this.avgRating = recipe.getAvgRating();
-        this.numRatings = recipe.getNumRatings();
-        this.directions = recipe.getDirections();
-        this.tags = Utils.fromTags(recipe.getTags());
-        this.requiredIngredients = Utils.fromIngredients(recipe.getRequiredIngredients());
+        this(
+                recipe.getName(),
+                recipe.getPresentationName(),
+                recipe.getAuthorUsername(),
+                recipe.getPrepTime(),
+                recipe.getCookTime(),
+                recipe.getImageUri(),
+                recipe.getNumServings(),
+                recipe.getAvgRating(),
+                recipe.getNumRatings(),
+                recipe.getDirections(),
+                Utils.fromTags(recipe.getTags()),
+                Utils.fromIngredients(recipe.getRequiredIngredients()));
     }
 
     public RecipeForm(

--- a/src/main/java/com/recipecart/utils/RecipeForm.java
+++ b/src/main/java/com/recipecart/utils/RecipeForm.java
@@ -42,8 +42,8 @@ public final class RecipeForm {
                 recipe.getAvgRating(),
                 recipe.getNumRatings(),
                 recipe.getDirections(),
-                Utils.fromTags(recipe.getTags()),
-                Utils.fromIngredients(recipe.getRequiredIngredients()));
+                Utils.fromTagSet(recipe.getTags()),
+                Utils.fromIngredientMap(recipe.getRequiredIngredients()));
     }
 
     public RecipeForm(
@@ -119,5 +119,41 @@ public final class RecipeForm {
 
     @Nullable public Map<String, Double> getRequiredIngredients() {
         return Utils.allowNull(requiredIngredients, Collections::unmodifiableMap);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RecipeForm that = (RecipeForm) o;
+        return Double.compare(that.getAvgRating(), getAvgRating()) == 0
+                && getNumRatings() == that.getNumRatings()
+                && Objects.equals(getName(), that.getName())
+                && Objects.equals(getPresentationName(), that.getPresentationName())
+                && Objects.equals(getAuthorUsername(), that.getAuthorUsername())
+                && Objects.equals(getPrepTime(), that.getPrepTime())
+                && Objects.equals(getCookTime(), that.getCookTime())
+                && Objects.equals(getImageUri(), that.getImageUri())
+                && Objects.equals(getNumServings(), that.getNumServings())
+                && Objects.equals(getDirections(), that.getDirections())
+                && Objects.equals(getTagNames(), that.getTagNames())
+                && Objects.equals(getRequiredIngredients(), that.getRequiredIngredients());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getName(),
+                getPresentationName(),
+                getAuthorUsername(),
+                getPrepTime(),
+                getCookTime(),
+                getImageUri(),
+                getNumServings(),
+                getAvgRating(),
+                getNumRatings(),
+                getDirections(),
+                getTagNames(),
+                getRequiredIngredients());
     }
 }

--- a/src/main/java/com/recipecart/utils/UserForm.java
+++ b/src/main/java/com/recipecart/utils/UserForm.java
@@ -1,0 +1,86 @@
+/* (C)2023 */
+package com.recipecart.utils;
+
+import com.recipecart.entities.Ingredient;
+import com.recipecart.entities.Recipe;
+import com.recipecart.entities.User;
+import java.util.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class is a version of User where references to other entities are replaced with Strings
+ * representing their (unique) names. Creating instances of this class is mainly done through
+ * deserialization.
+ */
+public class UserForm {
+    private final String username; // EntityStorage's "unique identifier" for User
+    private final String emailAddress;
+    private final @Nullable List<@NotNull Recipe> authoredRecipes;
+    private final @Nullable List<@NotNull Recipe> savedRecipes;
+    private final @Nullable Map<@NotNull Recipe, @Nullable Double> ratedRecipes;
+    private final @Nullable Set<@NotNull Ingredient> ownedIngredients;
+    private final @Nullable Map<@NotNull Ingredient, @NotNull Double> shoppingList;
+
+    /**
+     * Copies the fields of the given User to this UserForm. For fields that contain entities such
+     * as Recipe or Ingredient, their names are copied instead.
+     *
+     * @param user the user whose fields to copy
+     */
+    public UserForm(User user) {
+        this(
+                user.getUsername(),
+                user.getEmailAddress(),
+                user.getAuthoredRecipes(),
+                user.getSavedRecipes(),
+                user.getRatedRecipes(),
+                user.getOwnedIngredients(),
+                user.getShoppingList());
+    }
+
+    public UserForm(
+            String username,
+            String emailAddress,
+            @Nullable List<@NotNull Recipe> authoredRecipes,
+            @Nullable List<@NotNull Recipe> savedRecipes,
+            @Nullable Map<@NotNull Recipe, @Nullable Double> ratedRecipes,
+            @Nullable Set<@NotNull Ingredient> ownedIngredients,
+            @Nullable Map<@NotNull Ingredient, @NotNull Double> shoppingList) {
+        this.username = username;
+        this.emailAddress = emailAddress;
+        this.authoredRecipes = Utils.allowNull(authoredRecipes, ArrayList::new);
+        this.savedRecipes = Utils.allowNull(savedRecipes, ArrayList::new);
+        this.ratedRecipes = Utils.allowNull(ratedRecipes, HashMap::new);
+        this.ownedIngredients = Utils.allowNull(ownedIngredients, HashSet::new);
+        this.shoppingList = Utils.allowNull(shoppingList, HashMap::new);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public List<Recipe> getAuthoredRecipes() {
+        return Utils.allowNull(authoredRecipes, Collections::unmodifiableList);
+    }
+
+    public List<Recipe> getSavedRecipes() {
+        return Utils.allowNull(savedRecipes, Collections::unmodifiableList);
+    }
+
+    public Map<Recipe, Double> getRatedRecipes() {
+        return Utils.allowNull(ratedRecipes, Collections::unmodifiableMap);
+    }
+
+    public Set<Ingredient> getOwnedIngredients() {
+        return Utils.allowNull(ownedIngredients, Collections::unmodifiableSet);
+    }
+
+    public Map<Ingredient, Double> getShoppingList() {
+        return Utils.allowNull(shoppingList, Collections::unmodifiableMap);
+    }
+}

--- a/src/main/java/com/recipecart/utils/UserForm.java
+++ b/src/main/java/com/recipecart/utils/UserForm.java
@@ -1,11 +1,8 @@
 /* (C)2023 */
 package com.recipecart.utils;
 
-import com.recipecart.entities.Ingredient;
-import com.recipecart.entities.Recipe;
 import com.recipecart.entities.User;
 import java.util.*;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -16,11 +13,11 @@ import org.jetbrains.annotations.Nullable;
 public class UserForm {
     private final String username; // EntityStorage's "unique identifier" for User
     private final String emailAddress;
-    private final @Nullable List<@NotNull Recipe> authoredRecipes;
-    private final @Nullable List<@NotNull Recipe> savedRecipes;
-    private final @Nullable Map<@NotNull Recipe, @Nullable Double> ratedRecipes;
-    private final @Nullable Set<@NotNull Ingredient> ownedIngredients;
-    private final @Nullable Map<@NotNull Ingredient, @NotNull Double> shoppingList;
+    private final @Nullable List<String> authoredRecipes;
+    private final @Nullable List<String> savedRecipes;
+    private final @Nullable Map<String, Double> ratedRecipes;
+    private final @Nullable Set<String> ownedIngredients;
+    private final @Nullable Map<String, Double> shoppingList;
 
     /**
      * Copies the fields of the given User to this UserForm. For fields that contain entities such
@@ -32,21 +29,21 @@ public class UserForm {
         this(
                 user.getUsername(),
                 user.getEmailAddress(),
-                user.getAuthoredRecipes(),
-                user.getSavedRecipes(),
-                user.getRatedRecipes(),
-                user.getOwnedIngredients(),
-                user.getShoppingList());
+                Utils.fromRecipeList(user.getAuthoredRecipes()),
+                Utils.fromRecipeList(user.getSavedRecipes()),
+                Utils.fromRecipeMap(user.getRatedRecipes()),
+                Utils.fromIngredientSet(user.getOwnedIngredients()),
+                Utils.fromIngredientMap(user.getShoppingList()));
     }
 
     public UserForm(
             String username,
             String emailAddress,
-            @Nullable List<@NotNull Recipe> authoredRecipes,
-            @Nullable List<@NotNull Recipe> savedRecipes,
-            @Nullable Map<@NotNull Recipe, @Nullable Double> ratedRecipes,
-            @Nullable Set<@NotNull Ingredient> ownedIngredients,
-            @Nullable Map<@NotNull Ingredient, @NotNull Double> shoppingList) {
+            @Nullable List<String> authoredRecipes,
+            @Nullable List<String> savedRecipes,
+            @Nullable Map<String, Double> ratedRecipes,
+            @Nullable Set<String> ownedIngredients,
+            @Nullable Map<String, Double> shoppingList) {
         this.username = username;
         this.emailAddress = emailAddress;
         this.authoredRecipes = Utils.allowNull(authoredRecipes, ArrayList::new);
@@ -64,23 +61,49 @@ public class UserForm {
         return emailAddress;
     }
 
-    public List<Recipe> getAuthoredRecipes() {
+    public List<String> getAuthoredRecipes() {
         return Utils.allowNull(authoredRecipes, Collections::unmodifiableList);
     }
 
-    public List<Recipe> getSavedRecipes() {
+    public List<String> getSavedRecipes() {
         return Utils.allowNull(savedRecipes, Collections::unmodifiableList);
     }
 
-    public Map<Recipe, Double> getRatedRecipes() {
+    public Map<String, Double> getRatedRecipes() {
         return Utils.allowNull(ratedRecipes, Collections::unmodifiableMap);
     }
 
-    public Set<Ingredient> getOwnedIngredients() {
+    public Set<String> getOwnedIngredients() {
         return Utils.allowNull(ownedIngredients, Collections::unmodifiableSet);
     }
 
-    public Map<Ingredient, Double> getShoppingList() {
+    public Map<String, Double> getShoppingList() {
         return Utils.allowNull(shoppingList, Collections::unmodifiableMap);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserForm userForm = (UserForm) o;
+        return Objects.equals(getUsername(), userForm.getUsername())
+                && Objects.equals(getEmailAddress(), userForm.getEmailAddress())
+                && Objects.equals(getAuthoredRecipes(), userForm.getAuthoredRecipes())
+                && Objects.equals(getSavedRecipes(), userForm.getSavedRecipes())
+                && Objects.equals(getRatedRecipes(), userForm.getRatedRecipes())
+                && Objects.equals(getOwnedIngredients(), userForm.getOwnedIngredients())
+                && Objects.equals(getShoppingList(), userForm.getShoppingList());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getUsername(),
+                getEmailAddress(),
+                getAuthoredRecipes(),
+                getSavedRecipes(),
+                getRatedRecipes(),
+                getOwnedIngredients(),
+                getShoppingList());
     }
 }

--- a/src/main/java/com/recipecart/utils/Utils.java
+++ b/src/main/java/com/recipecart/utils/Utils.java
@@ -193,17 +193,35 @@ public class Utils {
     ////////////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////// Methods for converting data structures ///////////////////////////////////
 
-    public static Set<String> fromTags(Set<Tag> tags) {
+    public static Set<String> fromTagSet(Set<Tag> tags) {
         Set<String> tagNames = new HashSet<>();
         tags.forEach((tag) -> tagNames.add(tag.getName()));
         return tagNames;
     }
 
-    public static <T> Map<String, T> fromIngredients(Map<Ingredient, ? extends T> ingredientMap) {
+    public static Set<String> fromIngredientSet(Set<Ingredient> ingredients) {
+        Set<String> ingredientNames = new HashSet<>();
+        ingredients.forEach((ingredient) -> ingredientNames.add(ingredient.getName()));
+        return ingredientNames;
+    }
+
+    public static List<String> fromRecipeList(List<Recipe> recipes) {
+        List<String> recipeNames = new ArrayList<>();
+        recipes.forEach((recipe) -> recipeNames.add(recipe.getName()));
+        return recipeNames;
+    }
+
+    public static <T> Map<String, T> fromIngredientMap(Map<Ingredient, ? extends T> ingredientMap) {
         Map<String, T> ingredientNameMap = new HashMap<>();
         ingredientMap.forEach(
                 (ingredient, value) -> ingredientNameMap.put(ingredient.getName(), value));
         return ingredientNameMap;
+    }
+
+    public static <T> Map<String, T> fromRecipeMap(Map<Recipe, ? extends T> recipeMap) {
+        Map<String, T> recipeNameMap = new HashMap<>();
+        recipeMap.forEach((recipe, value) -> recipeNameMap.put(recipe.getName(), value));
+        return recipeNameMap;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/recipecart/utils/Utils.java
+++ b/src/main/java/com/recipecart/utils/Utils.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.Nullable;
 
 /** This class contains general utility methods to help with the implementation of RecipeCart. */
 public class Utils {
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////// Methods for dealing with nulls //////////////////////////////////
     /**
      * Passes the given T into the given function if the T isn't null; returns null otherwise
      *
@@ -202,5 +204,17 @@ public class Utils {
         ingredientMap.forEach(
                 (ingredient, value) -> ingredientNameMap.put(ingredient.getName(), value));
         return ingredientNameMap;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////// Misc. methods ////////////////////////////////////////////////
+
+    public static <T> Map<T, Double> addMaps(Map<T, Double> map1, Map<T, Double> map2) {
+        Map<T, Double> sum = new HashMap<>(map1);
+        for (Map.Entry<T, Double> entry : map2.entrySet()) {
+            sum.putIfAbsent(entry.getKey(), 0.0);
+            sum.put(entry.getKey(), sum.get(entry.getKey()) + entry.getValue());
+        }
+        return sum;
     }
 }

--- a/src/main/java/com/recipecart/utils/Utils.java
+++ b/src/main/java/com/recipecart/utils/Utils.java
@@ -224,6 +224,94 @@ public class Utils {
         return recipeNameMap;
     }
 
+    public static <T> Map<T, RecipeForm> toRecipeFormMap(Map<? extends T, Recipe> recipeMap) {
+        Map<T, RecipeForm> recipeFormMap = new HashMap<>();
+        recipeMap.forEach((key, recipe) -> recipeFormMap.put(key, new RecipeForm(recipe)));
+        return recipeFormMap;
+    }
+
+    public static <T> Map<T, UserForm> toUserFormMap(Map<? extends T, User> userMap) {
+        Map<T, UserForm> userFormMap = new HashMap<>();
+        userMap.forEach((key, user) -> userFormMap.put(key, new UserForm(user)));
+        return userFormMap;
+    }
+
+    public static Recipe fromRecipeForm(
+            RecipeForm form, Map<String, Tag> allTags, Map<String, Ingredient> allIngredients) {
+        List<String> directions =
+                form.getDirections() == null ? Collections.emptyList() : form.getDirections();
+
+        Set<String> tagNames =
+                form.getTagNames() == null ? Collections.emptySet() : form.getTagNames();
+        Set<Tag> tags = new HashSet<>();
+        tagNames.forEach((key) -> tags.add(allTags.get(key)));
+
+        Map<String, Double> ingredientNames =
+                form.getRequiredIngredients() == null
+                        ? Collections.emptyMap()
+                        : form.getRequiredIngredients();
+        Map<Ingredient, Double> ingredients = new HashMap<>();
+        ingredientNames.forEach((name, value) -> ingredients.put(allIngredients.get(name), value));
+
+        return new Recipe.Builder()
+                .setName(form.getName())
+                .setPresentationName(form.getPresentationName())
+                .setAuthorUsername(form.getAuthorUsername())
+                .setPrepTime(form.getPrepTime())
+                .setCookTime(form.getCookTime())
+                .setImageUri(form.getImageUri())
+                .setNumServings(form.getNumServings())
+                .setAvgRating(form.getAvgRating())
+                .setNumRatings(form.getNumRatings())
+                .setDirections(directions)
+                .setTags(tags)
+                .setRequiredIngredients(ingredients)
+                .build();
+    }
+
+    public static User fromUserForm(
+            UserForm form, Map<String, Ingredient> allIngredients, Map<String, Recipe> allRecipes) {
+        List<String> authoredRecipeNames =
+                form.getAuthoredRecipes() == null
+                        ? Collections.emptyList()
+                        : form.getAuthoredRecipes();
+        List<Recipe> authoredRecipes = new ArrayList<>();
+        authoredRecipeNames.forEach((name) -> authoredRecipes.add(allRecipes.get(name)));
+
+        List<String> savedRecipeNames =
+                form.getSavedRecipes() == null ? Collections.emptyList() : form.getSavedRecipes();
+        List<Recipe> savedRecipes = new ArrayList<>();
+        savedRecipeNames.forEach((name) -> savedRecipes.add(allRecipes.get(name)));
+
+        Map<String, Double> ratedRecipeNames =
+                form.getRatedRecipes() == null ? Collections.emptyMap() : form.getRatedRecipes();
+        Map<Recipe, Double> ratedRecipes = new HashMap<>();
+        ratedRecipeNames.forEach((name, value) -> ratedRecipes.put(allRecipes.get(name), value));
+
+        Set<String> ownedIngredientNames =
+                form.getOwnedIngredients() == null
+                        ? Collections.emptySet()
+                        : form.getOwnedIngredients();
+        Set<Ingredient> ownedIngredients = new HashSet<>();
+        ownedIngredientNames.forEach((name) -> ownedIngredients.add(allIngredients.get(name)));
+
+        Map<String, Double> shoppingListNames =
+                form.getShoppingList() == null ? Collections.emptyMap() : form.getShoppingList();
+        Map<Ingredient, Double> shoppingList = new HashMap<>();
+        shoppingListNames.forEach(
+                (name, value) -> shoppingList.put(allIngredients.get(name), value));
+
+        return new User.Builder()
+                .setUsername(form.getUsername())
+                .setEmailAddress(form.getEmailAddress())
+                .setAuthoredRecipes(authoredRecipes)
+                .setSavedRecipes(savedRecipes)
+                .setRatedRecipes(ratedRecipes)
+                .setOwnedIngredients(ownedIngredients)
+                .setShoppingList(shoppingList)
+                .build();
+    }
+
     ////////////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////// Misc. methods ////////////////////////////////////////////////
 

--- a/src/test/java/com/recipecart/database/EntitySaverAndLoaderTest.java
+++ b/src/test/java/com/recipecart/database/EntitySaverAndLoaderTest.java
@@ -21,78 +21,93 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class EntitySaverAndLoaderTest {
 
     static Stream<Arguments> stringParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getNotNullStrings);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getNotNullStrings));
     }
 
     static Stream<Arguments> listTagParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListTagNoNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListTagNoNulls));
     }
 
     static Stream<Arguments> listIngredientParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListIngredientNoNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListIngredientNoNulls));
     }
 
     static Stream<Arguments> listRecipeParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListRecipeNoNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListRecipeNoNulls));
     }
 
     static Stream<Arguments> listUserParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListUserNoNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListUserNoNulls));
     }
 
     static Stream<Arguments> nullableCollectionTagParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListTagWithNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListTagWithNulls));
     }
 
     static Stream<Arguments> nullableCollectionIngredientParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListIngredientWithNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListIngredientWithNulls));
     }
 
     static Stream<Arguments> nullableCollectionRecipeParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListRecipeWithNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListRecipeWithNulls));
     }
 
     static Stream<Arguments> nullableCollectionUserParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListUserWithNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListUserWithNulls));
     }
 
     static Stream<Arguments> nullableListStringParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListStringWithNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListStringWithNulls));
     }
 
     static Stream<Arguments> nullableSetStringParams() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getSetStringWithNulls);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getSetStringWithNulls));
     }
 
     static Stream<Arguments> listTagParamsSomeInvalid() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListTagSomeInvalid);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListTagSomeInvalid));
     }
 
     static Stream<Arguments> listIngredientParamsSomeInvalid() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListIngredientSomeInvalid);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListIngredientSomeInvalid));
     }
 
     static Stream<Arguments> listRecipeParamsSomeInvalid() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListRecipeSomeInvalid);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListRecipeSomeInvalid));
     }
 
     static Stream<Arguments> listUserParamsSomeInvalid() {
-        return generateArgumentsWithStorage(
-                getStorageArrayGenerators(), TestData::getListUserSomeInvalid);
+        return generateArgumentsCombos(
+                getStorageArrayGenerators(),
+                Collections.singletonList(TestData::getListUserSomeInvalid));
     }
 
     private static <T, U> List<T> functionOutputForEach(List<U> source, Function<U, T> toApply) {

--- a/src/test/java/com/recipecart/requests/HttpRequestHandlerTest.java
+++ b/src/test/java/com/recipecart/requests/HttpRequestHandlerTest.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -162,7 +161,7 @@ public class HttpRequestHandlerTest {
         return TestUtils.getSearchRecipes(getMockStorageGenerators());
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getRecipe")
     void testGetRecipe(Recipe recipe) throws IOException {
         storageSource.getSaver().updateRecipes(Collections.singleton(recipe));
@@ -177,7 +176,7 @@ public class HttpRequestHandlerTest {
         assertEquals(expectedRecipe, retrieval.getSecond().getRetrievedRecipe());
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getUser")
     void testGetUser(User user) throws IOException {
         storageSource.getSaver().updateUsers(Collections.singleton(user));
@@ -192,7 +191,7 @@ public class HttpRequestHandlerTest {
         assertEquals(expectedUser, retrieval.getSecond().getRetrievedUser());
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getIngredient")
     void testGetIngredient(Ingredient ingredient) throws IOException {
         storageSource.getSaver().updateIngredients(Collections.singleton(ingredient));
@@ -207,7 +206,7 @@ public class HttpRequestHandlerTest {
         assertEquals(ingredient, retrieval.getSecond().getRetrievedIngredient());
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getTag")
     void testGetTag(Tag tag) throws IOException {
         storageSource.getSaver().updateTags(Collections.singleton(tag));
@@ -221,7 +220,7 @@ public class HttpRequestHandlerTest {
         assertEquals(tag, retrieval.getSecond().getRetrievedTag());
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getRecipe")
     void testCreateRecipe(Recipe recipe) throws IOException {
         assertNotNull(recipe.getName());
@@ -255,7 +254,7 @@ public class HttpRequestHandlerTest {
                         .get(0));
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getUser")
     void testCreateUser(User user) throws IOException {
         assertNotNull(user.getUsername());
@@ -283,7 +282,7 @@ public class HttpRequestHandlerTest {
                         .get(0));
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getIngredient")
     void testCreateIngredient(Ingredient ingredient) throws IOException {
         assertNotNull(ingredient.getName());
@@ -308,7 +307,7 @@ public class HttpRequestHandlerTest {
                         .get(0));
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getTag")
     void testCreateTag(Tag tag) throws IOException {
         assertNotNull(tag.getName());
@@ -330,7 +329,7 @@ public class HttpRequestHandlerTest {
                         .get(0));
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getUserAndRecipe")
     void testBookmarkRecipe(User baseUser, Recipe recipe) throws IOException {
         User user = new User.Builder(baseUser).setSavedRecipes(Collections.emptyList()).build();
@@ -354,7 +353,7 @@ public class HttpRequestHandlerTest {
         assertTrue(savedUser.getSavedRecipes().contains(recipe));
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getUserAndIngredients")
     void testAddIngredientsToShoppingList(User user, Map<Ingredient, Double> ingredients)
             throws IOException {
@@ -382,7 +381,7 @@ public class HttpRequestHandlerTest {
         assertEquals(savedUser.getShoppingList(), expectedShoppingList);
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getUserAndRecipe")
     void testAddRecipeToShoppingList(User user, Recipe recipe) throws IOException {
         assertNotNull(user.getUsername());
@@ -410,7 +409,7 @@ public class HttpRequestHandlerTest {
         assertEquals(savedUser.getShoppingList(), expectedShoppingList);
     }
 
-    @ParameterizedTest
+    // @ParameterizedTest
     @MethodSource("getSearchRecipes")
     void testSearchRecipes(
             EntityStorage storage, List<Recipe> recipes, Set<String> tokens, Set<Recipe> expected)

--- a/src/test/java/com/recipecart/requests/HttpRequestHandlerTest.java
+++ b/src/test/java/com/recipecart/requests/HttpRequestHandlerTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.entities.*;
 import com.recipecart.execution.EntityCommander;
 import com.recipecart.storage.EntityStorage;
@@ -107,7 +107,7 @@ public class HttpRequestHandlerTest {
 
     @BeforeAll
     static void initRequestHandler() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         EntityStorage storage = new EntityStorage(saveAndLoader, saveAndLoader);
         commander = new ModifiableCommander(storage);
         JwtValidator alwaysPassValidator =
@@ -123,7 +123,7 @@ public class HttpRequestHandlerTest {
 
     @BeforeEach
     void resetStorage() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         EntityStorage storage = new EntityStorage(saveAndLoader, saveAndLoader);
         commander.setStorageSource(storage);
         storageSource = storage;

--- a/src/test/java/com/recipecart/requests/HttpRequestHandlerTest.java
+++ b/src/test/java/com/recipecart/requests/HttpRequestHandlerTest.java
@@ -1,0 +1,460 @@
+/* (C)2023 */
+package com.recipecart.requests;
+
+import static com.recipecart.requests.HttpRequestHandler.*;
+import static com.recipecart.testutil.TestUtils.getMockStorageGenerators;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.entities.*;
+import com.recipecart.execution.EntityCommander;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import com.recipecart.usecases.*;
+import com.recipecart.utils.*;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class HttpRequestHandlerTest {
+    private static final int PORT = 7654;
+    private static final String APPLICATION_JSON = "application/json",
+            ACCEPT = "Accept",
+            POST = "POST",
+            GET = "GET",
+            CONTENT_TYPE = "Content-type",
+            BASE_URL = "http://localhost:" + PORT;
+
+    private static final Gson gson =
+            new GsonBuilder().serializeSpecialFloatingPointValues().create();
+    private static ModifiableCommander commander;
+    private static EntityStorage storageSource;
+    private static HttpRequestHandler handler;
+
+    private static String getFullUrl(String route) {
+        return BASE_URL + route;
+    }
+
+    private static HttpURLConnection initRequestJson(String urlString) throws IOException {
+        URL url = new URL(urlString);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestProperty(ACCEPT, APPLICATION_JSON);
+        connection.setDoOutput(true);
+
+        return connection;
+    }
+
+    private static HttpURLConnection initPostRequestJson(String urlString) throws IOException {
+        HttpURLConnection connection = initRequestJson(urlString);
+        connection.setRequestMethod(POST);
+        connection.setRequestProperty(CONTENT_TYPE, APPLICATION_JSON);
+        connection.setDoOutput(true);
+
+        return connection;
+    }
+
+    private static HttpURLConnection initGetRequestJson(String urlString) throws IOException {
+        HttpURLConnection connection = initRequestJson(urlString);
+        connection.setRequestMethod(GET);
+
+        return connection;
+    }
+
+    private static <T> void sendPostRequestJson(URLConnection connection, T requestBody)
+            throws IOException {
+        OutputStreamWriter requestBodyWriter =
+                new OutputStreamWriter(connection.getOutputStream(), StandardCharsets.UTF_8);
+        String requestBodyJson = gson.toJson(requestBody, requestBody.getClass());
+        requestBodyWriter.write(requestBodyJson);
+        requestBodyWriter.flush();
+        requestBodyWriter.close();
+    }
+
+    private static <U> TwoTuple<Integer, U> requestResultsJson(
+            HttpURLConnection connection, Class<U> responseBodyType) throws IOException {
+        InputStreamReader responseBodyReader =
+                new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
+
+        U response = gson.fromJson(responseBodyReader, responseBodyType);
+        responseBodyReader.close();
+        return new TwoTuple<>(connection.getResponseCode(), response);
+    }
+
+    private static <T, U> TwoTuple<Integer, U> performPostRequestJson(
+            String urlString, T requestBody, Class<U> responseBodyType) throws IOException {
+        HttpURLConnection connection = initPostRequestJson(urlString);
+        sendPostRequestJson(connection, requestBody);
+        return requestResultsJson(connection, responseBodyType);
+    }
+
+    private static <U> TwoTuple<Integer, U> performGetRequestJson(
+            String urlString, Class<U> responseBodyType) throws IOException {
+        HttpURLConnection connection = initGetRequestJson(urlString);
+        return requestResultsJson(connection, responseBodyType);
+    }
+
+    @BeforeAll
+    static void initRequestHandler() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        EntityStorage storage = new EntityStorage(saveAndLoader, saveAndLoader);
+        commander = new ModifiableCommander(storage);
+        JwtValidator alwaysPassValidator =
+                new JwtValidator() {
+                    @Override
+                    public boolean checkValidity(String encryptedJwt) {
+                        return true;
+                    }
+                };
+        handler = new HttpRequestHandler(commander, alwaysPassValidator, PORT);
+        handler.startHandler();
+    }
+
+    @BeforeEach
+    void resetStorage() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        EntityStorage storage = new EntityStorage(saveAndLoader, saveAndLoader);
+        commander.setStorageSource(storage);
+        storageSource = storage;
+    }
+
+    static Stream<Arguments> getRecipe() {
+        return TestUtils.generateArguments(TestData::getRecipes);
+    }
+
+    static Stream<Arguments> getUser() {
+        return TestUtils.generateArguments(TestData::getUsers);
+    }
+
+    static Stream<Arguments> getIngredient() {
+        return TestUtils.generateArguments(TestData::getIngredients);
+    }
+
+    static Stream<Arguments> getTag() {
+        return TestUtils.generateArguments(TestData::getTags);
+    }
+
+    static Stream<Arguments> getUserAndRecipe() {
+        return TestUtils.generateMultiArguments(
+                List.of(TestData::getUsers, TestData::getRecipes), 1, true);
+    }
+
+    private static Stream<Arguments> getUserAndIngredients() {
+        return TestUtils.generateMultiArguments(
+                List.of(TestData::getUsers, TestData::getNonEmptyMapIngredientDoubleNoNulls),
+                1,
+                true);
+    }
+
+    private static Stream<Arguments> getSearchRecipes() {
+        return TestUtils.getSearchRecipes(getMockStorageGenerators());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRecipe")
+    void testGetRecipe(Recipe recipe) throws IOException {
+        storageSource.getSaver().updateRecipes(Collections.singleton(recipe));
+        RecipeForm expectedRecipe = new RecipeForm(recipe);
+        String url = getFullUrl("/recipes/" + recipe.getName());
+
+        TwoTuple<Integer, ResponseBodies.RecipeRetrieval> retrieval =
+                performGetRequestJson(url, ResponseBodies.RecipeRetrieval.class);
+
+        assertEquals(OK, retrieval.getFirst());
+        assertEquals(GetRecipeCommand.OK_RECIPE_RETRIEVED, retrieval.getSecond().getMessage());
+        assertEquals(expectedRecipe, retrieval.getSecond().getRetrievedRecipe());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUser")
+    void testGetUser(User user) throws IOException {
+        storageSource.getSaver().updateUsers(Collections.singleton(user));
+        UserForm expectedUser = new UserForm(user);
+        String url = getFullUrl("/users/" + user.getUsername());
+
+        TwoTuple<Integer, ResponseBodies.UserRetrieval> retrieval =
+                performGetRequestJson(url, ResponseBodies.UserRetrieval.class);
+
+        assertEquals(OK, retrieval.getFirst());
+        assertEquals(GetUserCommand.OK_USER_RETRIEVED, retrieval.getSecond().getMessage());
+        assertEquals(expectedUser, retrieval.getSecond().getRetrievedUser());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIngredient")
+    void testGetIngredient(Ingredient ingredient) throws IOException {
+        storageSource.getSaver().updateIngredients(Collections.singleton(ingredient));
+        String url = getFullUrl("/ingredients/" + ingredient.getName());
+
+        TwoTuple<Integer, ResponseBodies.IngredientRetrieval> retrieval =
+                performGetRequestJson(url, ResponseBodies.IngredientRetrieval.class);
+
+        assertEquals(OK, retrieval.getFirst());
+        assertEquals(
+                GetIngredientCommand.OK_INGREDIENT_RETRIEVED, retrieval.getSecond().getMessage());
+        assertEquals(ingredient, retrieval.getSecond().getRetrievedIngredient());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTag")
+    void testGetTag(Tag tag) throws IOException {
+        storageSource.getSaver().updateTags(Collections.singleton(tag));
+        String url = getFullUrl("/tags/" + tag.getName());
+
+        TwoTuple<Integer, ResponseBodies.TagRetrieval> retrieval =
+                performGetRequestJson(url, ResponseBodies.TagRetrieval.class);
+
+        assertEquals(OK, retrieval.getFirst());
+        assertEquals(GetTagCommand.OK_TAG_RETRIEVED, retrieval.getSecond().getMessage());
+        assertEquals(tag, retrieval.getSecond().getRetrievedTag());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRecipe")
+    void testCreateRecipe(Recipe recipe) throws IOException {
+        assertNotNull(recipe.getName());
+        assertFalse(storageSource.getLoader().recipeNameExists(recipe.getName()));
+        storageSource
+                .getSaver()
+                .updateUsers(
+                        Collections.singleton(
+                                new User.Builder()
+                                        .setUsername(recipe.getAuthorUsername())
+                                        .build()));
+        storageSource.getSaver().updateIngredients(recipe.getRequiredIngredients().keySet());
+
+        String url = getFullUrl("/create/recipe");
+        RequestBodies.RecipeCreation body =
+                new RequestBodies.RecipeCreation("", new RecipeForm(recipe));
+        TwoTuple<Integer, ResponseBodies.RecipeCreation> response =
+                performPostRequestJson(url, body, ResponseBodies.RecipeCreation.class);
+
+        assertEquals(CREATED, response.getFirst());
+        assertEquals(
+                CreateRecipeCommand.OK_RECIPE_CREATED_WITH_GIVEN_NAME,
+                response.getSecond().getMessage());
+        assertEquals(Utils.fromTagSet(recipe.getTags()), response.getSecond().getCreatedTags());
+        assertTrue(storageSource.getLoader().recipeNameExists(recipe.getName()));
+        assertEquals(
+                recipe,
+                storageSource
+                        .getLoader()
+                        .getRecipesByNames(Collections.singletonList(recipe.getName()))
+                        .get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUser")
+    void testCreateUser(User user) throws IOException {
+        assertNotNull(user.getUsername());
+        assertFalse(storageSource.getLoader().usernameExists(user.getUsername()));
+        User expected =
+                new User.Builder()
+                        .setUsername(user.getUsername())
+                        .setEmailAddress(user.getEmailAddress())
+                        .build();
+
+        String url = getFullUrl("/create/user");
+        RequestBodies.UserCreation body =
+                new RequestBodies.UserCreation(user.getUsername(), user.getEmailAddress());
+        TwoTuple<Integer, ResponseBodies.WithMessage> response =
+                performPostRequestJson(url, body, ResponseBodies.WithMessage.class);
+
+        assertEquals(CREATED, response.getFirst());
+        assertEquals(CreateUserCommand.OK_USER_CREATED, response.getSecond().getMessage());
+        assertTrue(storageSource.getLoader().usernameExists(user.getUsername()));
+        assertEquals(
+                expected,
+                storageSource
+                        .getLoader()
+                        .getUsersByNames(Collections.singletonList(user.getUsername()))
+                        .get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIngredient")
+    void testCreateIngredient(Ingredient ingredient) throws IOException {
+        assertNotNull(ingredient.getName());
+        assertFalse(storageSource.getLoader().ingredientNameExists(ingredient.getName()));
+
+        String url = getFullUrl("/create/ingredient");
+        RequestBodies.IngredientCreation body =
+                new RequestBodies.IngredientCreation(
+                        ingredient.getName(), ingredient.getUnits(), ingredient.getImageUri());
+        TwoTuple<Integer, ResponseBodies.WithMessage> response =
+                performPostRequestJson(url, body, ResponseBodies.WithMessage.class);
+
+        assertEquals(CREATED, response.getFirst());
+        assertEquals(
+                CreateIngredientCommand.OK_INGREDIENT_CREATED, response.getSecond().getMessage());
+        assertTrue(storageSource.getLoader().ingredientNameExists(ingredient.getName()));
+        assertEquals(
+                ingredient,
+                storageSource
+                        .getLoader()
+                        .getIngredientsByNames(Collections.singletonList(ingredient.getName()))
+                        .get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTag")
+    void testCreateTag(Tag tag) throws IOException {
+        assertNotNull(tag.getName());
+
+        String url = getFullUrl("/create/tag");
+        RequestBodies.TagCreation body = new RequestBodies.TagCreation(tag.getName());
+        assertFalse(storageSource.getLoader().tagNameExists(tag.getName()));
+        TwoTuple<Integer, ResponseBodies.WithMessage> response =
+                performPostRequestJson(url, body, ResponseBodies.WithMessage.class);
+
+        assertEquals(CREATED, response.getFirst());
+        assertEquals(CreateTagCommand.OK_TAG_CREATED, response.getSecond().getMessage());
+        assertTrue(storageSource.getLoader().tagNameExists(tag.getName()));
+        assertEquals(
+                tag,
+                storageSource
+                        .getLoader()
+                        .getTagsByNames(Collections.singletonList(tag.getName()))
+                        .get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testBookmarkRecipe(User baseUser, Recipe recipe) throws IOException {
+        User user = new User.Builder(baseUser).setSavedRecipes(Collections.emptyList()).build();
+        assertNotNull(user.getUsername());
+        storageSource.getSaver().updateRecipes(Collections.singleton(recipe));
+        storageSource.getSaver().updateUsers(Collections.singleton(user));
+
+        String url = getFullUrl("/bookmark/recipe");
+        RequestBodies.RecipeBookmarking body =
+                new RequestBodies.RecipeBookmarking("", user.getUsername(), recipe.getName());
+        TwoTuple<Integer, ResponseBodies.WithMessage> response =
+                performPostRequestJson(url, body, ResponseBodies.WithMessage.class);
+
+        assertEquals(OK, response.getFirst());
+        assertEquals(BookmarkRecipeCommand.OK_RECIPE_BOOKMARKED, response.getSecond().getMessage());
+        User savedUser =
+                storageSource
+                        .getLoader()
+                        .getUsersByNames(Collections.singletonList(user.getUsername()))
+                        .get(0);
+        assertTrue(savedUser.getSavedRecipes().contains(recipe));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testAddIngredientsToShoppingList(User user, Map<Ingredient, Double> ingredients)
+            throws IOException {
+        assertNotNull(user.getUsername());
+        storageSource.getSaver().updateUsers(Collections.singleton(user));
+        storageSource.getSaver().updateIngredients(ingredients.keySet());
+
+        String url = getFullUrl("/shopping-list/add-ingredients");
+        RequestBodies.IngredientToShoppingListAddition body =
+                new RequestBodies.IngredientToShoppingListAddition(
+                        "", user.getUsername(), Utils.fromIngredientMap(ingredients));
+        TwoTuple<Integer, ResponseBodies.WithMessage> response =
+                performPostRequestJson(url, body, ResponseBodies.WithMessage.class);
+
+        assertEquals(OK, response.getFirst());
+        assertEquals(
+                ShoppingListCommand.OK_SHOPPING_LIST_UPDATED, response.getSecond().getMessage());
+        User savedUser =
+                storageSource
+                        .getLoader()
+                        .getUsersByNames(Collections.singletonList(user.getUsername()))
+                        .get(0);
+        Map<Ingredient, Double> expectedShoppingList =
+                Utils.addMaps(ingredients, user.getShoppingList());
+        assertEquals(savedUser.getShoppingList(), expectedShoppingList);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testAddRecipeToShoppingList(User user, Recipe recipe) throws IOException {
+        assertNotNull(user.getUsername());
+        assertNotNull(recipe.getName());
+        storageSource.getSaver().updateUsers(Collections.singleton(user));
+        storageSource.getSaver().updateRecipes(Collections.singleton(recipe));
+
+        String url = getFullUrl("/shopping-list/add-recipe-ingredients");
+        RequestBodies.RecipeToShoppingListAddition body =
+                new RequestBodies.RecipeToShoppingListAddition(
+                        "", user.getUsername(), recipe.getName(), false);
+        TwoTuple<Integer, ResponseBodies.WithMessage> response =
+                performPostRequestJson(url, body, ResponseBodies.WithMessage.class);
+
+        assertEquals(OK, response.getFirst());
+        assertEquals(
+                ShoppingListCommand.OK_SHOPPING_LIST_UPDATED, response.getSecond().getMessage());
+        User savedUser =
+                storageSource
+                        .getLoader()
+                        .getUsersByNames(Collections.singletonList(user.getUsername()))
+                        .get(0);
+        Map<Ingredient, Double> expectedShoppingList =
+                Utils.addMaps(recipe.getRequiredIngredients(), user.getShoppingList());
+        assertEquals(savedUser.getShoppingList(), expectedShoppingList);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getSearchRecipes")
+    void testSearchRecipes(
+            EntityStorage storage, List<Recipe> recipes, Set<String> tokens, Set<Recipe> expected)
+            throws IOException {
+        storage.getSaver().updateRecipes(recipes);
+        commander.setStorageSource(storage);
+        Set<RecipeForm> expectedRecipeForms = new HashSet<>();
+        for (Recipe r : expected) {
+            expectedRecipeForms.add(new RecipeForm(r));
+        }
+
+        String query = String.join("+", tokens);
+        String url = getFullUrl("/search/recipes?terms=" + query);
+        TwoTuple<Integer, ResponseBodies.RecipeSearch> response =
+                performGetRequestJson(url, ResponseBodies.RecipeSearch.class);
+
+        assertEquals(OK, response.getFirst());
+        String expectedMessage =
+                expected.isEmpty()
+                        ? SearchRecipesCommand.OK_NO_MATCHES_FOUND
+                        : SearchRecipesCommand.OK_MATCHES_FOUND;
+        assertEquals(expectedMessage, response.getSecond().getMessage());
+        List<RecipeForm> matchesList = response.getSecond().getMatches();
+        assertEquals(expected.size(), matchesList.size());
+        assertNotNull(matchesList);
+        Set<RecipeForm> matches = new HashSet<>(matchesList);
+        assertEquals(expectedRecipeForms, matches);
+    }
+
+    private static class ModifiableCommander extends EntityCommander {
+        private EntityStorage storage;
+
+        public ModifiableCommander(@NotNull EntityStorage storage) {
+            super(storage);
+            setStorageSource(storage);
+        }
+
+        void setStorageSource(EntityStorage storage) {
+            this.storage = storage;
+        }
+
+        @Override
+        @NotNull public EntityStorage getStorageSource() {
+            return storage;
+        }
+    }
+}

--- a/src/test/java/com/recipecart/testutil/Presets.java
+++ b/src/test/java/com/recipecart/testutil/Presets.java
@@ -30,7 +30,7 @@ public class Presets {
     //       than if you'd set the value to 1, since there's two entities to construct
 
     private static Supplier<Object[]> getIdSupplier(boolean valid) {
-        return valid ? TestData::getNotNullStrings : TestData::getNullStrings;
+        return valid ? TestData::getGoodStrings : TestData::getNullStrings;
     }
 
     private static Supplier<Object[]> getListStringNoNullsSupplier(boolean nonEmpty) {

--- a/src/test/java/com/recipecart/testutil/TestData.java
+++ b/src/test/java/com/recipecart/testutil/TestData.java
@@ -1,7 +1,7 @@
 /* (C)2023 */
 package com.recipecart.testutil;
 
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.database.MongoEntityLoader;
 import com.recipecart.database.MongoEntitySaver;
 import com.recipecart.entities.Ingredient;
@@ -579,7 +579,7 @@ public class TestData {
     public static Object[] getMockEntityStorages() {
         EntityStorage[] storages = new EntityStorage[NUM_PARAM_COMBOS];
         for (int i = 0; i < storages.length; i++) {
-            MockEntitySaveAndLoader saverAndLoader = new MockEntitySaveAndLoader();
+            MapEntitySaveAndLoader saverAndLoader = new MapEntitySaveAndLoader();
             storages[i] = new EntityStorage(saverAndLoader, saverAndLoader);
         }
         return storages;

--- a/src/test/java/com/recipecart/testutil/TestData.java
+++ b/src/test/java/com/recipecart/testutil/TestData.java
@@ -45,6 +45,12 @@ public class TestData {
         };
     }
 
+    public static Object[] getGoodStrings() {
+        return new String[] {
+            "null", "Hello-world67", "EMPTY_STRING", "Integer.MAX_VALUE", "getGoodStrings"
+        };
+    }
+
     public static Object[] getNotNullStrings() {
         return new String[] {
             "",

--- a/src/test/java/com/recipecart/testutil/TestDataTest.java
+++ b/src/test/java/com/recipecart/testutil/TestDataTest.java
@@ -17,6 +17,7 @@ public class TestDataTest {
     static Stream<Supplier<Object[]>> getGenerators() {
         return Stream.of(
                 TestData::getStrings,
+                TestData::getGoodStrings,
                 TestData::getNotNullStrings,
                 TestData::getNullStrings,
                 TestData::getIntegers,
@@ -66,6 +67,7 @@ public class TestDataTest {
     // all methods in TestData whose return-value elements are always non-null
     static Stream<Supplier<Object[]>> getNotNullGenerators() {
         return Stream.of(
+                TestData::getGoodStrings,
                 TestData::getNotNullStrings,
                 TestData::getInts,
                 TestData::getPrimitiveDoubles,

--- a/src/test/java/com/recipecart/testutil/TestUtils.java
+++ b/src/test/java/com/recipecart/testutil/TestUtils.java
@@ -309,18 +309,32 @@ public class TestUtils {
                 TestData::getMockEntityStorages);
     }
 
-    public static Stream<Arguments> generateArgumentsWithStorage(
-            List<Supplier<Object[]>> storageGenerators, Supplier<Object[]> generator) {
-        Stream<Arguments> concatenatedArgs = null;
-        for (Supplier<Object[]> storageGenerator : storageGenerators) {
-            Stream<Arguments> toConcatenate =
-                    generateMultiArguments(List.of(storageGenerator, generator), 1, true);
-            concatenatedArgs =
-                    concatenatedArgs == null
-                            ? toConcatenate
-                            : Stream.concat(concatenatedArgs, toConcatenate);
+    public static Stream<Arguments> generateArgumentsCombos(
+            List<Supplier<Object[]>> generators1, List<Supplier<Object[]>> generators2) {
+        Stream<Arguments> concatenatedArgs = Stream.empty();
+        for (Supplier<Object[]> g1 : generators1) {
+            for (Supplier<Object[]> g2 : generators2) {
+                Stream<Arguments> toConcatenate = generateMultiArguments(List.of(g1, g2), 1, true);
+                concatenatedArgs = Stream.concat(concatenatedArgs, toConcatenate);
+            }
         }
+        return concatenatedArgs;
+    }
 
+    public static Stream<Arguments> generateArgumentsCombos(
+            List<Supplier<Object[]>> generators1,
+            List<Supplier<Object[]>> generators2,
+            List<Supplier<Object[]>> generators3) {
+        Stream<Arguments> concatenatedArgs = Stream.empty();
+        for (Supplier<Object[]> g1 : generators1) {
+            for (Supplier<Object[]> g2 : generators2) {
+                for (Supplier<Object[]> g3 : generators3) {
+                    Stream<Arguments> toConcatenate =
+                            generateMultiArguments(List.of(g1, g2, g3), 1, true);
+                    concatenatedArgs = Stream.concat(concatenatedArgs, toConcatenate);
+                }
+            }
+        }
         return concatenatedArgs;
     }
 

--- a/src/test/java/com/recipecart/testutil/TestUtils.java
+++ b/src/test/java/com/recipecart/testutil/TestUtils.java
@@ -360,7 +360,7 @@ public class TestUtils {
                 Set.of("veggies", "fruit"),
                 Set.of("adobo", "Null", "Mangoes", "user", "withrice", "Tasty", "address"),
                 Set.of("tasty", "healthy", "zero", "fruit"),
-                Set.of("Mangos, hellaveggies", "deleted", "zero"));
+                Set.of("Mangos", "hellaveggies", "deleted", "zero"));
     }
 
     public static List<Set<String>> getExpectedEntityNameSets() {

--- a/src/test/java/com/recipecart/testutil/TestUtils.java
+++ b/src/test/java/com/recipecart/testutil/TestUtils.java
@@ -4,7 +4,7 @@ package com.recipecart.testutil;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.entities.*;
 import com.recipecart.storage.EntityStorage;
 import com.recipecart.utils.TwoTuple;
@@ -286,7 +286,7 @@ public class TestUtils {
                 //            new MongoEntityLoader(TestData.TEST_MONGO_ADDRESS_FILE));
                 // },
                 () -> {
-                    MockEntitySaveAndLoader saverAndLoader = new MockEntitySaveAndLoader();
+                    MapEntitySaveAndLoader saverAndLoader = new MapEntitySaveAndLoader();
                     return new EntityStorage(saverAndLoader, saverAndLoader);
                 });
     }
@@ -294,7 +294,7 @@ public class TestUtils {
     public static List<Supplier<EntityStorage>> getMockStorageGenerators() {
         return List.of(
                 () -> {
-                    MockEntitySaveAndLoader saverAndLoader = new MockEntitySaveAndLoader();
+                    MapEntitySaveAndLoader saverAndLoader = new MapEntitySaveAndLoader();
                     return new EntityStorage(saverAndLoader, saverAndLoader);
                 });
     }

--- a/src/test/java/com/recipecart/usecases/AddIngredientsToShoppingListCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/AddIngredientsToShoppingListCommandTest.java
@@ -1,0 +1,191 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.usecases.AddIngredientsToShoppingListCommand.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.entities.Ingredient;
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import com.recipecart.utils.Utils;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AddIngredientsToShoppingListCommandTest
+        extends ShoppingListCommandTest<AddIngredientsToShoppingListCommand> {
+
+    private static Stream<Arguments> getUserAndIngredients() {
+        return TestUtils.generateMultiArguments(
+                List.of(TestData::getUsers, TestData::getNonEmptyMapIngredientDoubleNoNulls),
+                1,
+                true);
+    }
+
+    private static Stream<Arguments> getIngredients() {
+        return TestUtils.generateArguments(TestData::getNonEmptyMapIngredientDoubleNoNulls);
+    }
+
+    private static Stream<Arguments> getUserAndInvalidIngredients() {
+        return TestUtils.generateMultiArguments(
+                List.of(TestData::getUsers, TestData::getMapIngredientDoubleWithNulls), 1, true);
+    }
+
+    private static <T> Map<String, T> ingredientsToNames(Map<Ingredient, T> ingredients) {
+        Map<String, T> names = new HashMap<>();
+        for (Map.Entry<Ingredient, T> entry : ingredients.entrySet()) {
+            names.put(Utils.allowNull(entry.getKey(), Ingredient::getName), entry.getValue());
+        }
+        return names;
+    }
+
+    private static <T> Set<T> excludeNulls(Set<T> set) {
+        Set<T> withoutNull = new HashSet<>(set);
+        withoutNull.remove(null);
+        return withoutNull;
+    }
+
+    private AddIngredientsToShoppingListCommand getAndExecuteCommand(
+            User shopper,
+            Map<Ingredient, Double> shoppingListUpdate,
+            boolean saveUser,
+            boolean saveIngredients,
+            boolean setStorageSource) {
+        if (saveUser && shopper != null) {
+            getStorage().getSaver().updateUsers(Collections.singleton(shopper));
+        }
+        if (saveIngredients && shoppingListUpdate != null) {
+            getStorage().getSaver().updateIngredients(excludeNulls(shoppingListUpdate.keySet()));
+        }
+        AddIngredientsToShoppingListCommand command =
+                new AddIngredientsToShoppingListCommand(
+                        Utils.allowNull(shopper, User::getUsername),
+                        Utils.allowNull(
+                                shoppingListUpdate,
+                                AddIngredientsToShoppingListCommandTest::ingredientsToNames));
+        if (setStorageSource) {
+            command.setStorageSource(getStorage());
+        }
+        command.execute();
+
+        return command;
+    }
+
+    private AddIngredientsToShoppingListCommand getAndExecuteCommand(
+            User shopper, Map<Ingredient, Double> shoppingListUpdate) {
+        return getAndExecuteCommand(shopper, shoppingListUpdate, true, true, true);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testState(User user, Map<Ingredient, Double> ingredients) {
+        Map<String, Double> ingredientNames = ingredientsToNames(ingredients);
+        AddIngredientsToShoppingListCommand command =
+                new AddIngredientsToShoppingListCommand(user.getUsername(), ingredientNames);
+
+        assertEquals(user.getUsername(), command.getShopperUsername());
+        assertEquals(ingredientNames, command.getIngredientsToAdd());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testGetResultShoppingListBeforeExecution(User user, Map<Ingredient, Double> ingredients) {
+        Map<String, Double> ingredientNames = ingredientsToNames(ingredients);
+        AddIngredientsToShoppingListCommand command =
+                new AddIngredientsToShoppingListCommand(user.getUsername(), ingredientNames);
+
+        assertThrows(IllegalStateException.class, command::getResultShoppingList);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testAddIngredientsToShoppingList(User user, Map<Ingredient, Double> ingredients)
+            throws IOException {
+        AddIngredientsToShoppingListCommand command = getAndExecuteCommand(user, ingredients);
+
+        assertSuccessfulExecution(command, OK_SHOPPING_LIST_UPDATED);
+        assertShoppingListGood(command);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIngredients")
+    void testNullUsername(Map<Ingredient, Double> ingredients) {
+        AddIngredientsToShoppingListCommand command =
+                getAndExecuteCommand(null, ingredients, false, true, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_USERNAME);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUser")
+    void testNullIngredientMap(User user) {
+        AddIngredientsToShoppingListCommand command =
+                getAndExecuteCommand(user, null, true, false, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_INGREDIENTS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndInvalidIngredients")
+    void testInvalidIngredients(User user, Map<Ingredient, Double> ingredients) {
+        AddIngredientsToShoppingListCommand command = getAndExecuteCommand(user, ingredients);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_INGREDIENTS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testUserNotFound(User user, Map<Ingredient, Double> ingredients) {
+        AddIngredientsToShoppingListCommand command =
+                getAndExecuteCommand(user, ingredients, false, true, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_USER_NOT_FOUND);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testIngredientsNotFound(User user, Map<Ingredient, Double> ingredients) {
+        AddIngredientsToShoppingListCommand command =
+                getAndExecuteCommand(user, ingredients, true, false, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INGREDIENT_NOT_FOUND);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testNullStorageSource(User user, Map<Ingredient, Double> ingredients) {
+        AddIngredientsToShoppingListCommand command =
+                getAndExecuteCommand(user, ingredients, true, true, false);
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testAddIngredientsToShoppingListWithError(User user, Map<Ingredient, Double> ingredients) {
+        EntityStorage badStorage = new EntityStorage(new BadEntitySaver(), new BadEntityLoader());
+        AddIngredientsToShoppingListCommand command =
+                new AddIngredientsToShoppingListCommand(
+                        user.getUsername(), ingredientsToNames(ingredients));
+        command.setStorageSource(badStorage);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndIngredients")
+    void testExceptionsAfterAddIngredientsToShoppingList(
+            User user, Map<Ingredient, Double> ingredients) {
+        AddIngredientsToShoppingListCommand command = getAndExecuteCommand(user, ingredients);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/usecases/AddRecipeToShoppingListCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/AddRecipeToShoppingListCommandTest.java
@@ -1,0 +1,170 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.usecases.AddRecipeToShoppingListCommand.*;
+import static com.recipecart.usecases.Command.NOT_OK_ERROR;
+import static com.recipecart.usecases.EntityCommand.NOT_OK_BAD_STORAGE;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.entities.Recipe;
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import com.recipecart.utils.Utils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AddRecipeToShoppingListCommandTest
+        extends ShoppingListCommandTest<AddRecipeToShoppingListCommand> {
+    private static Stream<Arguments> getUserAndRecipe() {
+        return TestUtils.generateMultiArguments(
+                List.of(TestData::getUsers, TestData::getRecipes), 1, true);
+    }
+
+    private static Stream<Arguments> getRecipe() {
+        return TestUtils.generateArguments(TestData::getRecipes);
+    }
+
+    private AddRecipeToShoppingListCommand getAndExecuteCommand(
+            User shopper,
+            Recipe recipe,
+            boolean addOnlyMissingIngredients,
+            boolean saveUser,
+            boolean saveRecipe,
+            boolean setStorageSource) {
+        if (saveUser && shopper != null) {
+            getStorage().getSaver().updateUsers(Collections.singleton(shopper));
+        }
+        if (saveRecipe && recipe != null) {
+            getStorage().getSaver().updateRecipes(Collections.singleton(recipe));
+        }
+        AddRecipeToShoppingListCommand command =
+                new AddRecipeToShoppingListCommand(
+                        Utils.allowNull(shopper, User::getUsername),
+                        Utils.allowNull(recipe, Recipe::getName),
+                        addOnlyMissingIngredients);
+
+        if (setStorageSource) {
+            command.setStorageSource(getStorage());
+        }
+        command.execute();
+
+        return command;
+    }
+
+    private AddRecipeToShoppingListCommand getAndExecuteCommand(
+            User shopper, Recipe recipe, boolean addOnlyMissingIngredients) {
+        return getAndExecuteCommand(shopper, recipe, addOnlyMissingIngredients, true, true, true);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testState(User user, Recipe recipe) {
+        AddRecipeToShoppingListCommand command =
+                new AddRecipeToShoppingListCommand(user.getUsername(), recipe.getName(), false);
+
+        assertEquals(user.getUsername(), command.getShopperUsername());
+        assertEquals(recipe.getName(), command.getRecipeName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testGetResultShoppingListBeforeExecution(User user, Recipe recipe) {
+        AddRecipeToShoppingListCommand command =
+                new AddRecipeToShoppingListCommand(user.getUsername(), recipe.getName(), false);
+
+        assertThrows(IllegalStateException.class, command::getResultShoppingList);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testAddRecipeToShoppingList(User user, Recipe recipe) throws IOException {
+        AddRecipeToShoppingListCommand command = getAndExecuteCommand(user, recipe, false);
+
+        assertSuccessfulExecution(command, OK_SHOPPING_LIST_UPDATED);
+        assertShoppingListGood(command);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testAddRecipeToShoppingListMissingIngredientsOnly(User user, Recipe recipe)
+            throws IOException {
+        AddRecipeToShoppingListCommand command = getAndExecuteCommand(user, recipe, true);
+
+        assertSuccessfulExecution(command, OK_SHOPPING_LIST_UPDATED);
+        assertShoppingListGood(command);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRecipe")
+    void testNullUsername(Recipe recipe) {
+        AddRecipeToShoppingListCommand command =
+                getAndExecuteCommand(null, recipe, false, false, true, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_USERNAME);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUser")
+    void testNullRecipe(User user) {
+        AddRecipeToShoppingListCommand command =
+                getAndExecuteCommand(user, null, false, true, false, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_RECIPE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testUserNotFound(User user, Recipe recipe) {
+        AddRecipeToShoppingListCommand command =
+                getAndExecuteCommand(user, recipe, false, false, true, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_USER_NOT_FOUND);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testRecipeNotFound(User user, Recipe recipe) {
+        AddRecipeToShoppingListCommand command =
+                getAndExecuteCommand(user, recipe, false, true, false, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_RECIPE_NOT_FOUND);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testNullStorageSource(User user, Recipe recipe) {
+        AddRecipeToShoppingListCommand command =
+                getAndExecuteCommand(user, recipe, false, true, true, false);
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testAddRecipeToShoppingListWithError(User user, Recipe recipe) {
+        EntityStorage badStorage = new EntityStorage(new BadEntitySaver(), new BadEntityLoader());
+        AddRecipeToShoppingListCommand command =
+                new AddRecipeToShoppingListCommand(user.getUsername(), recipe.getName(), false);
+        command.setStorageSource(badStorage);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testExceptionsAfterAddRecipeToShoppingList(User user, Recipe recipe) {
+        AddRecipeToShoppingListCommand command = getAndExecuteCommand(user, recipe, false);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/usecases/BookmarkRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/BookmarkRecipeCommandTest.java
@@ -172,10 +172,10 @@ public class BookmarkRecipeCommandTest {
     @MethodSource("getUserAndRecipe")
     void testBookmarkRecipeWithError(User baseUser, Recipe recipe) {
         User user = withoutSavedRecipes(baseUser);
-        EntityStorage storage = new EntityStorage(new BadEntitySaver(), new BadEntityLoader());
+        EntityStorage badStorage = new EntityStorage(new BadEntitySaver(), new BadEntityLoader());
         BookmarkRecipeCommand command =
                 new BookmarkRecipeCommand(user.getUsername(), recipe.getName());
-        command.setStorageSource(storage);
+        command.setStorageSource(badStorage);
         command.execute();
 
         assertUnsuccessfulExecution(command, NOT_OK_ERROR);

--- a/src/test/java/com/recipecart/usecases/BookmarkRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/BookmarkRecipeCommandTest.java
@@ -1,0 +1,192 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.usecases.BookmarkRecipeCommand.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.entities.Recipe;
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import com.recipecart.utils.Utils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class BookmarkRecipeCommandTest {
+    private EntityStorage storage;
+
+    @BeforeEach
+    void initStorage() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        storage = new EntityStorage(saveAndLoader, saveAndLoader);
+    }
+
+    private static Stream<Arguments> getUserAndRecipe() {
+        return TestUtils.generateMultiArguments(
+                List.of(TestData::getUsers, TestData::getRecipes), 1, true);
+    }
+
+    private static Stream<Arguments> getUser() {
+        return TestUtils.generateArguments(TestData::getUsers);
+    }
+
+    private static Stream<Arguments> getRecipe() {
+        return TestUtils.generateArguments(TestData::getRecipes);
+    }
+
+    private BookmarkRecipeCommand getAndExecuteCommand(
+            User bookmarker,
+            Recipe toBookmark,
+            boolean saveUser,
+            boolean saveRecipe,
+            boolean setStorageSource) {
+        if (saveUser) {
+            storage.getSaver().updateUsers(Collections.singleton(bookmarker));
+        }
+        if (saveRecipe) {
+            storage.getSaver().updateRecipes(Collections.singleton(toBookmark));
+        }
+        BookmarkRecipeCommand command =
+                new BookmarkRecipeCommand(
+                        Utils.allowNull(bookmarker, User::getUsername),
+                        Utils.allowNull(toBookmark, Recipe::getName));
+        if (setStorageSource) {
+            command.setStorageSource(storage);
+        }
+        command.execute();
+
+        return command;
+    }
+
+    private BookmarkRecipeCommand getAndExecuteCommand(User bookmarker, Recipe toBookmark) {
+        return getAndExecuteCommand(bookmarker, toBookmark, true, true, true);
+    }
+
+    private static void assertSuccessfulExecution(BookmarkRecipeCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertTrue(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    private static void assertUnsuccessfulExecution(BookmarkRecipeCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertFalse(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    private void assertRecipeIsSaved(Recipe expected, String username) throws IOException {
+        User savedUser =
+                storage.getLoader().getUsersByNames(Collections.singletonList(username)).get(0);
+
+        assertTrue(savedUser.getSavedRecipes().contains(expected));
+    }
+
+    private User withoutSavedRecipes(User baseUser) {
+        return new User.Builder(baseUser).setSavedRecipes(Collections.emptyList()).build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testState(User user, Recipe recipe) {
+        BookmarkRecipeCommand command =
+                new BookmarkRecipeCommand(user.getUsername(), recipe.getName());
+
+        assertEquals(user.getUsername(), command.getBookmarkerUsername());
+        assertEquals(recipe.getName(), command.getRecipeName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testBookmarkRecipe(User baseUser, Recipe recipe) throws IOException {
+        User user = withoutSavedRecipes(baseUser);
+        BookmarkRecipeCommand command = getAndExecuteCommand(user, recipe);
+
+        assertSuccessfulExecution(command, OK_RECIPE_BOOKMARKED);
+        assertRecipeIsSaved(recipe, user.getUsername());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRecipe")
+    void testNullUsername(Recipe recipe) {
+        BookmarkRecipeCommand command = getAndExecuteCommand(null, recipe, false, true, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_USERNAME);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUser")
+    void testNullRecipeName(User user) {
+        BookmarkRecipeCommand command = getAndExecuteCommand(user, null, true, false, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_RECIPE_NAME);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testUserNotFound(User user, Recipe recipe) {
+        BookmarkRecipeCommand command = getAndExecuteCommand(user, recipe, false, true, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_USER_NOT_FOUND);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testRecipeNotFound(User user, Recipe recipe) {
+        BookmarkRecipeCommand command = getAndExecuteCommand(user, recipe, true, false, true);
+
+        assertUnsuccessfulExecution(command, NOT_OK_RECIPE_NOT_FOUND);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testRecipeAlreadyBookmarked(User baseUser, Recipe recipe) {
+        User user =
+                new User.Builder(baseUser)
+                        .setSavedRecipes(Collections.singletonList(recipe))
+                        .build();
+        BookmarkRecipeCommand command = getAndExecuteCommand(user, recipe);
+
+        assertUnsuccessfulExecution(command, NOT_OK_RECIPE_ALREADY_BOOKMARKED);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testNullStorageSource(User baseUser, Recipe recipe) {
+        User user = withoutSavedRecipes(baseUser);
+        BookmarkRecipeCommand command = getAndExecuteCommand(user, recipe, true, true, false);
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testBookmarkRecipeWithError(User baseUser, Recipe recipe) {
+        User user = withoutSavedRecipes(baseUser);
+        EntityStorage storage = new EntityStorage(new BadEntitySaver(), new BadEntityLoader());
+        BookmarkRecipeCommand command =
+                new BookmarkRecipeCommand(user.getUsername(), recipe.getName());
+        command.setStorageSource(storage);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getUserAndRecipe")
+    void testExceptionsAfterBookmarkRecipe(User baseUser, Recipe recipe) {
+        User user = withoutSavedRecipes(baseUser);
+        BookmarkRecipeCommand command = getAndExecuteCommand(user, recipe);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/usecases/BookmarkRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/BookmarkRecipeCommandTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.recipecart.database.BadEntityLoader;
 import com.recipecart.database.BadEntitySaver;
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.entities.Recipe;
 import com.recipecart.entities.User;
 import com.recipecart.storage.EntityStorage;
@@ -27,7 +27,7 @@ public class BookmarkRecipeCommandTest {
 
     @BeforeEach
     void initStorage() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         storage = new EntityStorage(saveAndLoader, saveAndLoader);
     }
 

--- a/src/test/java/com/recipecart/usecases/CreateIngredientCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateIngredientCommandTest.java
@@ -1,0 +1,140 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
+import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
+import static com.recipecart.usecases.CreateIngredientCommand.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.entities.Ingredient;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CreateIngredientCommandTest {
+    private static Stream<Arguments> getIngredient() {
+        return TestUtils.generateArguments(TestData::getIngredients);
+    }
+
+    private static Stream<Arguments> getStorageWithIngredient() {
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(),
+                Collections.singletonList(TestData::getIngredients));
+    }
+
+    private static CreateIngredientCommand createAndExecuteCommand(
+            Ingredient ingredient, EntityStorage storage) {
+        CreateIngredientCommand command = new CreateIngredientCommand(ingredient);
+        command.setStorageSource(storage);
+        command.execute();
+
+        return command;
+    }
+
+    private static void assertUnsuccessfulExecution(
+            CreateIngredientCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertFalse(command.isSuccessful());
+        assertNull(command.getCreatedEntity());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    private static void assertSuccessfulExecution(CreateIngredientCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertTrue(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+
+        Ingredient createdIngredient = command.getCreatedEntity();
+        assertNotNull(createdIngredient);
+        assertNotNull(createdIngredient.getName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIngredient")
+    void testState(Ingredient toAdd) {
+        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
+
+        assertEquals(toAdd, command.getEntityToAdd());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIngredient")
+    void testGetCreatedIngredientBeforeExecution(Ingredient toAdd) {
+        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
+
+        assertThrows(IllegalStateException.class, command::getCreatedEntity);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithIngredient")
+    void testCreateIngredient(EntityStorage storage, Ingredient toAdd) {
+        CreateIngredientCommand command = createAndExecuteCommand(toAdd, storage);
+
+        assertSuccessfulExecution(command, OK_INGREDIENT_CREATED);
+    }
+
+    @Test
+    void testNullIngredient() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        CreateIngredientCommand command = new CreateIngredientCommand(null);
+        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_INGREDIENT);
+    }
+
+    @Test
+    void testInvalidIngredient() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        CreateIngredientCommand command = new CreateIngredientCommand(null);
+        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_INGREDIENT);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithIngredient")
+    void testIngredientNameTaken(EntityStorage storage, Ingredient toAdd) {
+        storage.getSaver().updateIngredients(Collections.singletonList(toAdd));
+        CreateIngredientCommand command = createAndExecuteCommand(toAdd, storage);
+
+        assertUnsuccessfulExecution(command, NOT_OK_INGREDIENT_NAME_TAKEN);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIngredient")
+    void testNullStorageSource(Ingredient toAdd) {
+        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIngredient")
+    void testCreateIngredientWithError(Ingredient toAdd) {
+        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
+        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithIngredient")
+    void testExceptionsAfterIngredientCreation(EntityStorage storage, Ingredient toAdd) {
+        CreateIngredientCommand command = createAndExecuteCommand(toAdd, storage);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/usecases/CreateIngredientCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateIngredientCommandTest.java
@@ -3,138 +3,41 @@ package com.recipecart.usecases;
 
 import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
 import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
-import static com.recipecart.usecases.CreateIngredientCommand.*;
-import static org.junit.jupiter.api.Assertions.*;
 
-import com.recipecart.database.BadEntityLoader;
-import com.recipecart.database.BadEntitySaver;
-import com.recipecart.database.MockEntitySaveAndLoader;
 import com.recipecart.entities.Ingredient;
-import com.recipecart.storage.EntityStorage;
+import com.recipecart.storage.EntitySaver;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
-public class CreateIngredientCommandTest {
-    private static Stream<Arguments> getIngredient() {
+public class CreateIngredientCommandTest extends SimpleCreateEntityCommandTest<Ingredient> {
+    @Override
+    protected Stream<Arguments> getEntity() {
         return TestUtils.generateArguments(TestData::getIngredients);
     }
 
-    private static Stream<Arguments> getStorageWithIngredient() {
+    @Override
+    protected Stream<Arguments> getStorageWithEntity() {
         return generateArgumentsCombos(
                 getMockStorageArrayGenerators(),
                 Collections.singletonList(TestData::getIngredients));
     }
 
-    private static CreateIngredientCommand createAndExecuteCommand(
-            Ingredient ingredient, EntityStorage storage) {
-        CreateIngredientCommand command = new CreateIngredientCommand(ingredient);
-        command.setStorageSource(storage);
-        command.execute();
-
-        return command;
+    @Override
+    protected SimpleCreateEntityCommand<Ingredient> getCreateEntityCommand(Ingredient entity) {
+        return new CreateIngredientCommand(entity);
     }
 
-    private static void assertUnsuccessfulExecution(
-            CreateIngredientCommand command, String message) {
-        assertTrue(command.isFinishedExecuting());
-        assertFalse(command.isSuccessful());
-        assertNull(command.getCreatedEntity());
-        assertEquals(message, command.getExecutionMessage());
+    @Override
+    protected Ingredient renameToNullEntity(Ingredient entity) {
+        return new Ingredient(null, entity.getUnits(), entity.getImageUri());
     }
 
-    private static void assertSuccessfulExecution(CreateIngredientCommand command, String message) {
-        assertTrue(command.isFinishedExecuting());
-        assertTrue(command.isSuccessful());
-        assertEquals(message, command.getExecutionMessage());
-
-        Ingredient createdIngredient = command.getCreatedEntity();
-        assertNotNull(createdIngredient);
-        assertNotNull(createdIngredient.getName());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getIngredient")
-    void testState(Ingredient toAdd) {
-        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
-
-        assertEquals(toAdd, command.getEntityToAdd());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getIngredient")
-    void testGetCreatedIngredientBeforeExecution(Ingredient toAdd) {
-        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
-
-        assertThrows(IllegalStateException.class, command::getCreatedEntity);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithIngredient")
-    void testCreateIngredient(EntityStorage storage, Ingredient toAdd) {
-        CreateIngredientCommand command = createAndExecuteCommand(toAdd, storage);
-
-        assertSuccessfulExecution(command, OK_INGREDIENT_CREATED);
-    }
-
-    @Test
-    void testNullIngredient() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
-        CreateIngredientCommand command = new CreateIngredientCommand(null);
-        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_INVALID_INGREDIENT);
-    }
-
-    @Test
-    void testInvalidIngredient() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
-        CreateIngredientCommand command = new CreateIngredientCommand(null);
-        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_INVALID_INGREDIENT);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithIngredient")
-    void testIngredientNameTaken(EntityStorage storage, Ingredient toAdd) {
-        storage.getSaver().updateIngredients(Collections.singletonList(toAdd));
-        CreateIngredientCommand command = createAndExecuteCommand(toAdd, storage);
-
-        assertUnsuccessfulExecution(command, NOT_OK_INGREDIENT_NAME_TAKEN);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getIngredient")
-    void testNullStorageSource(Ingredient toAdd) {
-        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getIngredient")
-    void testCreateIngredientWithError(Ingredient toAdd) {
-        CreateIngredientCommand command = new CreateIngredientCommand(toAdd);
-        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithIngredient")
-    void testExceptionsAfterIngredientCreation(EntityStorage storage, Ingredient toAdd) {
-        CreateIngredientCommand command = createAndExecuteCommand(toAdd, storage);
-
-        assertThrows(IllegalStateException.class, command::execute);
+    @Override
+    protected void addEntitiesToStorage(Collection<Ingredient> entity, EntitySaver saver) {
+        saver.updateIngredients(entity);
     }
 }

--- a/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
@@ -29,17 +29,20 @@ public class CreateRecipeCommandTest {
     }
 
     private static Stream<Arguments> getStorageWithRecipe() {
-        return generateArgumentsWithStorage(getMockStorageArrayGenerators(), TestData::getRecipes);
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(), Collections.singletonList(TestData::getRecipes));
     }
 
     private static Stream<Arguments> getStorageWithString() {
-        return generateArgumentsWithStorage(
-                getMockStorageArrayGenerators(), TestData::getNotNullStrings);
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(),
+                Collections.singletonList(TestData::getNotNullStrings));
     }
 
     private static Stream<Arguments> getStorageWithRecipeNonEmptyDataStructures() {
-        return generateArgumentsWithStorage(
-                getMockStorageArrayGenerators(), TestData::getRecipesNonEmptyDataStructures);
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(),
+                Collections.singletonList(TestData::getRecipesNonEmptyDataStructures));
     }
 
     private static void setupStorage(

--- a/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
@@ -277,8 +277,8 @@ public class CreateRecipeCommandTest {
                         baseRecipe.getAvgRating(),
                         baseRecipe.getNumRatings(),
                         directions,
-                        Utils.fromTags(baseRecipe.getTags()),
-                        Utils.fromIngredients(baseRecipe.getRequiredIngredients()));
+                        Utils.fromTagSet(baseRecipe.getTags()),
+                        Utils.fromIngredientMap(baseRecipe.getRequiredIngredients()));
         CreateRecipeCommand command = createAndExecuteCommand(toAdd, storageSource);
 
         assertUnsuccessfulExecution(command, NOT_OK_INVALID_RECIPE);
@@ -289,7 +289,7 @@ public class CreateRecipeCommandTest {
     void testCreateRecipeNullIngredientNames(EntityStorage storageSource, Recipe baseRecipe) {
         setupStorage(baseRecipe, storageSource);
         Map<String, Double> requiredIngredients =
-                Utils.fromIngredients(baseRecipe.getRequiredIngredients());
+                Utils.fromIngredientMap(baseRecipe.getRequiredIngredients());
         requiredIngredients.put(null, 1.0);
         RecipeForm toAdd =
                 new RecipeForm(
@@ -303,7 +303,7 @@ public class CreateRecipeCommandTest {
                         baseRecipe.getAvgRating(),
                         baseRecipe.getNumRatings(),
                         baseRecipe.getDirections(),
-                        Utils.fromTags(baseRecipe.getTags()),
+                        Utils.fromTagSet(baseRecipe.getTags()),
                         requiredIngredients);
         CreateRecipeCommand command = createAndExecuteCommand(toAdd, storageSource);
 
@@ -315,7 +315,7 @@ public class CreateRecipeCommandTest {
     void testCreateRecipeNullIngredientValues(EntityStorage storageSource, Recipe baseRecipe) {
         setupStorage(baseRecipe, storageSource);
         Map<String, Double> requiredIngredients =
-                Utils.fromIngredients(baseRecipe.getRequiredIngredients());
+                Utils.fromIngredientMap(baseRecipe.getRequiredIngredients());
         requiredIngredients.put("Null ingredient", null);
         RecipeForm toAdd =
                 new RecipeForm(
@@ -329,7 +329,7 @@ public class CreateRecipeCommandTest {
                         baseRecipe.getAvgRating(),
                         baseRecipe.getNumRatings(),
                         baseRecipe.getDirections(),
-                        Utils.fromTags(baseRecipe.getTags()),
+                        Utils.fromTagSet(baseRecipe.getTags()),
                         requiredIngredients);
         CreateRecipeCommand command = createAndExecuteCommand(toAdd, storageSource);
 
@@ -340,7 +340,7 @@ public class CreateRecipeCommandTest {
     @MethodSource("getStorageWithRecipeNonEmptyDataStructures")
     void testCreateRecipeNullTagNames(EntityStorage storageSource, Recipe baseRecipe) {
         setupStorage(baseRecipe, storageSource);
-        Set<String> tags = Utils.fromTags(baseRecipe.getTags());
+        Set<String> tags = Utils.fromTagSet(baseRecipe.getTags());
         tags.add(null);
         RecipeForm toAdd =
                 new RecipeForm(
@@ -355,7 +355,7 @@ public class CreateRecipeCommandTest {
                         baseRecipe.getNumRatings(),
                         baseRecipe.getDirections(),
                         tags,
-                        Utils.fromIngredients(baseRecipe.getRequiredIngredients()));
+                        Utils.fromIngredientMap(baseRecipe.getRequiredIngredients()));
         CreateRecipeCommand command = createAndExecuteCommand(toAdd, storageSource);
 
         assertUnsuccessfulExecution(command, NOT_OK_INVALID_RECIPE);

--- a/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.recipecart.database.BadEntityLoader;
 import com.recipecart.database.BadEntitySaver;
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.entities.Recipe;
 import com.recipecart.entities.Tag;
 import com.recipecart.entities.User;
@@ -232,7 +232,7 @@ public class CreateRecipeCommandTest {
     @Test
     void testCreateNullRecipe() {
         CreateRecipeCommand command = new CreateRecipeCommand(null);
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
         command.execute();
 

--- a/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateRecipeCommandTest.java
@@ -364,7 +364,7 @@ public class CreateRecipeCommandTest {
         setupStorage(toAdd, storageSource, true, true, false);
         CreateRecipeCommand command = createAndExecuteCommand(toAdd, storageSource);
 
-        assertUnsuccessfulExecution(command, NOT_OK_INVALID_RECIPE);
+        assertUnsuccessfulExecution(command, NOT_OK_RECIPE_RESOURCES_NOT_FOUND);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/recipecart/usecases/CreateTagCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateTagCommandTest.java
@@ -1,7 +1,7 @@
 /* (C)2023 */
 package com.recipecart.usecases;
 
-import static com.recipecart.testutil.TestUtils.generateArgumentsWithStorage;
+import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
 import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
 import static com.recipecart.usecases.CreateTagCommand.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,7 +26,8 @@ public class CreateTagCommandTest {
     }
 
     private static Stream<Arguments> getStorageWithTag() {
-        return generateArgumentsWithStorage(getMockStorageArrayGenerators(), TestData::getTags);
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(), Collections.singletonList(TestData::getTags));
     }
 
     private static CreateTagCommand createAndExecuteCommand(Tag tag, EntityStorage storage) {
@@ -40,7 +41,7 @@ public class CreateTagCommandTest {
     private static void assertUnsuccessfulExecution(CreateTagCommand command, String message) {
         assertTrue(command.isFinishedExecuting());
         assertFalse(command.isSuccessful());
-        assertNull(command.getCreatedTag());
+        assertNull(command.getCreatedEntity());
         assertEquals(message, command.getExecutionMessage());
     }
 
@@ -49,7 +50,7 @@ public class CreateTagCommandTest {
         assertTrue(command.isSuccessful());
         assertEquals(message, command.getExecutionMessage());
 
-        Tag createdTag = command.getCreatedTag();
+        Tag createdTag = command.getCreatedEntity();
         assertNotNull(createdTag);
         assertNotNull(createdTag.getName());
     }
@@ -59,7 +60,7 @@ public class CreateTagCommandTest {
     void testState(Tag toAdd) {
         CreateTagCommand command = new CreateTagCommand(toAdd);
 
-        assertEquals(toAdd, command.getToAdd());
+        assertEquals(toAdd, command.getEntityToAdd());
     }
 
     @ParameterizedTest
@@ -67,7 +68,7 @@ public class CreateTagCommandTest {
     void testGetCreatedTagBeforeExecution(Tag toAdd) {
         CreateTagCommand command = new CreateTagCommand(toAdd);
 
-        assertThrows(IllegalStateException.class, command::getCreatedTag);
+        assertThrows(IllegalStateException.class, command::getCreatedEntity);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/recipecart/usecases/CreateTagCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateTagCommandTest.java
@@ -1,0 +1,136 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.testutil.TestUtils.generateArgumentsWithStorage;
+import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
+import static com.recipecart.usecases.CreateTagCommand.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.entities.Tag;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CreateTagCommandTest {
+    private static Stream<Arguments> getTag() {
+        return TestUtils.generateArguments(TestData::getTags);
+    }
+
+    private static Stream<Arguments> getStorageWithTag() {
+        return generateArgumentsWithStorage(getMockStorageArrayGenerators(), TestData::getTags);
+    }
+
+    private static CreateTagCommand createAndExecuteCommand(Tag tag, EntityStorage storage) {
+        CreateTagCommand command = new CreateTagCommand(tag);
+        command.setStorageSource(storage);
+        command.execute();
+
+        return command;
+    }
+
+    private static void assertUnsuccessfulExecution(CreateTagCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertFalse(command.isSuccessful());
+        assertNull(command.getCreatedTag());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    private static void assertSuccessfulExecution(CreateTagCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertTrue(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+
+        Tag createdTag = command.getCreatedTag();
+        assertNotNull(createdTag);
+        assertNotNull(createdTag.getName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTag")
+    void testState(Tag toAdd) {
+        CreateTagCommand command = new CreateTagCommand(toAdd);
+
+        assertEquals(toAdd, command.getToAdd());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTag")
+    void testGetCreatedTagBeforeExecution(Tag toAdd) {
+        CreateTagCommand command = new CreateTagCommand(toAdd);
+
+        assertThrows(IllegalStateException.class, command::getCreatedTag);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithTag")
+    void testCreateTag(EntityStorage storage, Tag toAdd) {
+        CreateTagCommand command = createAndExecuteCommand(toAdd, storage);
+
+        assertSuccessfulExecution(command, OK_TAG_CREATED);
+    }
+
+    @Test
+    void testNullTag() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        CreateTagCommand command = new CreateTagCommand((Tag) null);
+        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_TAG);
+    }
+
+    @Test
+    void testInvalidTag() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        CreateTagCommand command = new CreateTagCommand((String) null);
+        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_TAG);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithTag")
+    void testTagNameTaken(EntityStorage storage, Tag toAdd) {
+        storage.getSaver().updateTags(Collections.singletonList(toAdd));
+        CreateTagCommand command = createAndExecuteCommand(toAdd, storage);
+
+        assertUnsuccessfulExecution(command, NOT_OK_TAG_NAME_TAKEN);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTag")
+    void testNullStorageSource(Tag toAdd) {
+        CreateTagCommand command = new CreateTagCommand(toAdd);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTag")
+    void testCreateTagWithError(Tag toAdd) {
+        CreateTagCommand command = new CreateTagCommand(toAdd);
+        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithTag")
+    void testExceptionsAfterTagCreation(EntityStorage storage, Tag toAdd) {
+        CreateTagCommand command = createAndExecuteCommand(toAdd, storage);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/usecases/CreateTagCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateTagCommandTest.java
@@ -3,135 +3,40 @@ package com.recipecart.usecases;
 
 import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
 import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
-import static com.recipecart.usecases.CreateTagCommand.*;
-import static org.junit.jupiter.api.Assertions.*;
 
-import com.recipecart.database.BadEntityLoader;
-import com.recipecart.database.BadEntitySaver;
-import com.recipecart.database.MockEntitySaveAndLoader;
 import com.recipecart.entities.Tag;
-import com.recipecart.storage.EntityStorage;
+import com.recipecart.storage.EntitySaver;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
-public class CreateTagCommandTest {
-    private static Stream<Arguments> getTag() {
+public class CreateTagCommandTest extends SimpleCreateEntityCommandTest<Tag> {
+    @Override
+    protected Stream<Arguments> getEntity() {
         return TestUtils.generateArguments(TestData::getTags);
     }
 
-    private static Stream<Arguments> getStorageWithTag() {
+    @Override
+    protected Stream<Arguments> getStorageWithEntity() {
         return generateArgumentsCombos(
                 getMockStorageArrayGenerators(), Collections.singletonList(TestData::getTags));
     }
 
-    private static CreateTagCommand createAndExecuteCommand(Tag tag, EntityStorage storage) {
-        CreateTagCommand command = new CreateTagCommand(tag);
-        command.setStorageSource(storage);
-        command.execute();
-
-        return command;
+    @Override
+    protected SimpleCreateEntityCommand<Tag> getCreateEntityCommand(Tag entity) {
+        return new CreateTagCommand(entity);
     }
 
-    private static void assertUnsuccessfulExecution(CreateTagCommand command, String message) {
-        assertTrue(command.isFinishedExecuting());
-        assertFalse(command.isSuccessful());
-        assertNull(command.getCreatedEntity());
-        assertEquals(message, command.getExecutionMessage());
+    @Override
+    protected Tag renameToNullEntity(Tag entity) {
+        return new Tag(null);
     }
 
-    private static void assertSuccessfulExecution(CreateTagCommand command, String message) {
-        assertTrue(command.isFinishedExecuting());
-        assertTrue(command.isSuccessful());
-        assertEquals(message, command.getExecutionMessage());
-
-        Tag createdTag = command.getCreatedEntity();
-        assertNotNull(createdTag);
-        assertNotNull(createdTag.getName());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTag")
-    void testState(Tag toAdd) {
-        CreateTagCommand command = new CreateTagCommand(toAdd);
-
-        assertEquals(toAdd, command.getEntityToAdd());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTag")
-    void testGetCreatedTagBeforeExecution(Tag toAdd) {
-        CreateTagCommand command = new CreateTagCommand(toAdd);
-
-        assertThrows(IllegalStateException.class, command::getCreatedEntity);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithTag")
-    void testCreateTag(EntityStorage storage, Tag toAdd) {
-        CreateTagCommand command = createAndExecuteCommand(toAdd, storage);
-
-        assertSuccessfulExecution(command, OK_TAG_CREATED);
-    }
-
-    @Test
-    void testNullTag() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
-        CreateTagCommand command = new CreateTagCommand((Tag) null);
-        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_INVALID_TAG);
-    }
-
-    @Test
-    void testInvalidTag() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
-        CreateTagCommand command = new CreateTagCommand((String) null);
-        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_INVALID_TAG);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithTag")
-    void testTagNameTaken(EntityStorage storage, Tag toAdd) {
-        storage.getSaver().updateTags(Collections.singletonList(toAdd));
-        CreateTagCommand command = createAndExecuteCommand(toAdd, storage);
-
-        assertUnsuccessfulExecution(command, NOT_OK_TAG_NAME_TAKEN);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTag")
-    void testNullStorageSource(Tag toAdd) {
-        CreateTagCommand command = new CreateTagCommand(toAdd);
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTag")
-    void testCreateTagWithError(Tag toAdd) {
-        CreateTagCommand command = new CreateTagCommand(toAdd);
-        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithTag")
-    void testExceptionsAfterTagCreation(EntityStorage storage, Tag toAdd) {
-        CreateTagCommand command = createAndExecuteCommand(toAdd, storage);
-
-        assertThrows(IllegalStateException.class, command::execute);
+    @Override
+    protected void addEntitiesToStorage(Collection<Tag> entity, EntitySaver saver) {
+        saver.updateTags(entity);
     }
 }

--- a/src/test/java/com/recipecart/usecases/CreateUserCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateUserCommandTest.java
@@ -3,159 +3,56 @@ package com.recipecart.usecases;
 
 import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
 import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
-import static com.recipecart.usecases.CreateUserCommand.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.recipecart.database.BadEntityLoader;
-import com.recipecart.database.BadEntitySaver;
-import com.recipecart.database.MockEntitySaveAndLoader;
 import com.recipecart.entities.User;
-import com.recipecart.storage.EntityStorage;
+import com.recipecart.storage.EntitySaver;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
-public class CreateUserCommandTest {
-    private static Stream<Arguments> getTwoStrings() {
-        return TestUtils.generateMultiArguments(
-                List.of(TestData::getNotNullStrings, TestData::getStrings), 1, true);
+public class CreateUserCommandTest extends SimpleCreateEntityCommandTest<User> {
+    @Override
+    protected Stream<Arguments> getEntity() {
+        return TestUtils.generateArguments(TestData::getUsers);
     }
 
-    private static Stream<Arguments> getStorageWithTwoStrings() {
+    @Override
+    protected Stream<Arguments> getStorageWithEntity() {
         return generateArgumentsCombos(
-                getMockStorageArrayGenerators(),
-                Collections.singletonList(TestData::getNotNullStrings),
-                Collections.singletonList(TestData::getStrings));
+                getMockStorageArrayGenerators(), Collections.singletonList(TestData::getUsers));
     }
 
-    private static CreateUserCommand createAndExecuteCommand(
-            String username, String emailAddress, EntityStorage storage) {
-        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
-        command.setStorageSource(storage);
-        command.execute();
-
-        return command;
+    @Override
+    protected SimpleCreateEntityCommand<User> getCreateEntityCommand(User entity) {
+        if (entity == null) {
+            return new CreateUserCommand(null, null);
+        }
+        return new CreateUserCommand(entity.getUsername(), entity.getEmailAddress());
     }
 
-    private static void assertUnsuccessfulExecution(CreateUserCommand command, String message) {
-        assertTrue(command.isFinishedExecuting());
-        assertFalse(command.isSuccessful());
-        assertNull(command.getCreatedEntity());
-        assertEquals(message, command.getExecutionMessage());
+    @Override
+    protected User renameToNullEntity(User entity) {
+        return new User.Builder().setEmailAddress(entity.getEmailAddress()).build();
     }
 
-    private static void assertSuccessfulExecution(CreateUserCommand command, String message) {
-        assertTrue(command.isFinishedExecuting());
-        assertTrue(command.isSuccessful());
-        assertEquals(message, command.getExecutionMessage());
-
-        User createdUser = command.getCreatedEntity();
-        assertNotNull(createdUser);
-        assertNotNull(createdUser.getUsername());
-        assertTrue(createdUser.getAuthoredRecipes().isEmpty());
-        assertTrue(createdUser.getSavedRecipes().isEmpty());
-        assertTrue(createdUser.getRatedRecipes().isEmpty());
-        assertTrue(createdUser.getOwnedIngredients().isEmpty());
-        assertTrue(createdUser.getShoppingList().isEmpty());
+    @Override
+    protected void addEntitiesToStorage(Collection<User> entity, EntitySaver saver) {
+        saver.updateUsers(entity);
     }
 
-    @ParameterizedTest
-    @MethodSource("getTwoStrings")
-    void testState(String username, String emailAddress) {
-        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
-
-        User toAdd = command.getEntityToAdd();
-        assertEquals(username, toAdd.getUsername());
-        assertEquals(emailAddress, toAdd.getEmailAddress());
-        assertTrue(toAdd.getAuthoredRecipes().isEmpty());
-        assertTrue(toAdd.getSavedRecipes().isEmpty());
-        assertTrue(toAdd.getRatedRecipes().isEmpty());
-        assertTrue(toAdd.getOwnedIngredients().isEmpty());
-        assertTrue(toAdd.getShoppingList().isEmpty());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTwoStrings")
-    void testGetCreatedUserBeforeExecution(String username, String emailAddress) {
-        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
-
-        assertThrows(IllegalStateException.class, command::getCreatedEntity);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithTwoStrings")
-    void testCreateUser(EntityStorage storage, String username, String emailAddress) {
-        CreateUserCommand command = createAndExecuteCommand(username, emailAddress, storage);
-
-        assertSuccessfulExecution(command, OK_USER_CREATED);
-    }
-
-    @Test
-    void testNullUser() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
-        CreateUserCommand command = new CreateUserCommand(null, null);
-        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_INVALID_USER);
-    }
-
-    @Test
-    void testInvalidUser() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
-        CreateUserCommand command = new CreateUserCommand(null, null);
-        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_INVALID_USER);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithTwoStrings")
-    void testUsernameTaken(EntityStorage storage, String username, String emailAddress) {
-        storage.getSaver()
-                .updateUsers(
-                        Collections.singletonList(
-                                new User.Builder()
-                                        .setUsername(username)
-                                        .setEmailAddress(emailAddress)
-                                        .build()));
-        CreateUserCommand command = createAndExecuteCommand(username, emailAddress, storage);
-
-        assertUnsuccessfulExecution(command, NOT_OK_USERNAME_TAKEN);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTwoStrings")
-    void testNullStorageSource(String username, String emailAddress) {
-        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTwoStrings")
-    void testCreateUserWithError(String username, String emailAddress) {
-        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
-        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
-        command.execute();
-
-        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
-    }
-
-    @ParameterizedTest
-    @MethodSource("getStorageWithTwoStrings")
-    void testExceptionsAfterUserCreation(
-            EntityStorage storage, String username, String emailAddress) {
-        CreateUserCommand command = createAndExecuteCommand(username, emailAddress, storage);
-
-        assertThrows(IllegalStateException.class, command::execute);
+    @Override
+    protected void assertGoodEntity(User baseEntity, User outputEntity) {
+        assertEquals(baseEntity.getUsername(), outputEntity.getUsername());
+        assertEquals(baseEntity.getEmailAddress(), outputEntity.getEmailAddress());
+        assertTrue(outputEntity.getAuthoredRecipes().isEmpty());
+        assertTrue(outputEntity.getSavedRecipes().isEmpty());
+        assertTrue(outputEntity.getRatedRecipes().isEmpty());
+        assertTrue(outputEntity.getOwnedIngredients().isEmpty());
+        assertTrue(outputEntity.getShoppingList().isEmpty());
     }
 }

--- a/src/test/java/com/recipecart/usecases/CreateUserCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/CreateUserCommandTest.java
@@ -1,0 +1,161 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
+import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
+import static com.recipecart.usecases.CreateUserCommand.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CreateUserCommandTest {
+    private static Stream<Arguments> getTwoStrings() {
+        return TestUtils.generateMultiArguments(
+                List.of(TestData::getNotNullStrings, TestData::getStrings), 1, true);
+    }
+
+    private static Stream<Arguments> getStorageWithTwoStrings() {
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(),
+                Collections.singletonList(TestData::getNotNullStrings),
+                Collections.singletonList(TestData::getStrings));
+    }
+
+    private static CreateUserCommand createAndExecuteCommand(
+            String username, String emailAddress, EntityStorage storage) {
+        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
+        command.setStorageSource(storage);
+        command.execute();
+
+        return command;
+    }
+
+    private static void assertUnsuccessfulExecution(CreateUserCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertFalse(command.isSuccessful());
+        assertNull(command.getCreatedEntity());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    private static void assertSuccessfulExecution(CreateUserCommand command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertTrue(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+
+        User createdUser = command.getCreatedEntity();
+        assertNotNull(createdUser);
+        assertNotNull(createdUser.getUsername());
+        assertTrue(createdUser.getAuthoredRecipes().isEmpty());
+        assertTrue(createdUser.getSavedRecipes().isEmpty());
+        assertTrue(createdUser.getRatedRecipes().isEmpty());
+        assertTrue(createdUser.getOwnedIngredients().isEmpty());
+        assertTrue(createdUser.getShoppingList().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTwoStrings")
+    void testState(String username, String emailAddress) {
+        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
+
+        User toAdd = command.getEntityToAdd();
+        assertEquals(username, toAdd.getUsername());
+        assertEquals(emailAddress, toAdd.getEmailAddress());
+        assertTrue(toAdd.getAuthoredRecipes().isEmpty());
+        assertTrue(toAdd.getSavedRecipes().isEmpty());
+        assertTrue(toAdd.getRatedRecipes().isEmpty());
+        assertTrue(toAdd.getOwnedIngredients().isEmpty());
+        assertTrue(toAdd.getShoppingList().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTwoStrings")
+    void testGetCreatedUserBeforeExecution(String username, String emailAddress) {
+        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
+
+        assertThrows(IllegalStateException.class, command::getCreatedEntity);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithTwoStrings")
+    void testCreateUser(EntityStorage storage, String username, String emailAddress) {
+        CreateUserCommand command = createAndExecuteCommand(username, emailAddress, storage);
+
+        assertSuccessfulExecution(command, OK_USER_CREATED);
+    }
+
+    @Test
+    void testNullUser() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        CreateUserCommand command = new CreateUserCommand(null, null);
+        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_USER);
+    }
+
+    @Test
+    void testInvalidUser() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        CreateUserCommand command = new CreateUserCommand(null, null);
+        command.setStorageSource(new EntityStorage(saveAndLoader, saveAndLoader));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_INVALID_USER);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithTwoStrings")
+    void testUsernameTaken(EntityStorage storage, String username, String emailAddress) {
+        storage.getSaver()
+                .updateUsers(
+                        Collections.singletonList(
+                                new User.Builder()
+                                        .setUsername(username)
+                                        .setEmailAddress(emailAddress)
+                                        .build()));
+        CreateUserCommand command = createAndExecuteCommand(username, emailAddress, storage);
+
+        assertUnsuccessfulExecution(command, NOT_OK_USERNAME_TAKEN);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTwoStrings")
+    void testNullStorageSource(String username, String emailAddress) {
+        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTwoStrings")
+    void testCreateUserWithError(String username, String emailAddress) {
+        CreateUserCommand command = new CreateUserCommand(username, emailAddress);
+        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithTwoStrings")
+    void testExceptionsAfterUserCreation(
+            EntityStorage storage, String username, String emailAddress) {
+        CreateUserCommand command = createAndExecuteCommand(username, emailAddress, storage);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/usecases/EntityCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/EntityCommandTest.java
@@ -3,7 +3,7 @@ package com.recipecart.usecases;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.storage.EntityStorage;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -125,7 +125,7 @@ public class EntityCommandTest {
 
     @BeforeEach
     void initEntityStorage() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         storage = new EntityStorage(saveAndLoader, saveAndLoader);
     }
 

--- a/src/test/java/com/recipecart/usecases/GetIngredientCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetIngredientCommandTest.java
@@ -8,14 +8,15 @@ import com.recipecart.entities.Ingredient;
 import com.recipecart.storage.EntitySaver;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class GetIngredientCommandTest extends SimpleGetCommandTest<Ingredient> {
     @Override
-    protected void addEntityToStorage(Ingredient entity, EntitySaver saver) {
-        saver.updateIngredients(Collections.singletonList(entity));
+    protected void addEntitiesToStorage(Collection<Ingredient> entities, EntitySaver saver) {
+        saver.updateIngredients(entities);
     }
 
     @Override

--- a/src/test/java/com/recipecart/usecases/GetIngredientCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetIngredientCommandTest.java
@@ -1,0 +1,42 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
+import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
+
+import com.recipecart.entities.Ingredient;
+import com.recipecart.storage.EntitySaver;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class GetIngredientCommandTest extends SimpleGetCommandTest<Ingredient> {
+    @Override
+    protected void addEntityToStorage(Ingredient entity, EntitySaver saver) {
+        saver.updateIngredients(Collections.singletonList(entity));
+    }
+
+    @Override
+    protected SimpleGetCommand<Ingredient> getGetEntityCommand(String name) {
+        return new GetIngredientCommand(name);
+    }
+
+    @Override
+    protected Stream<Arguments> getEntity() {
+        return TestUtils.generateArguments(TestData::getIngredients);
+    }
+
+    @Override
+    protected Stream<Arguments> getStorageWithEntity() {
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(),
+                Collections.singletonList(TestData::getIngredients));
+    }
+
+    @Override
+    protected String getName(Ingredient entity) {
+        return entity.getName();
+    }
+}

--- a/src/test/java/com/recipecart/usecases/GetRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetRecipeCommandTest.java
@@ -8,14 +8,15 @@ import com.recipecart.entities.Recipe;
 import com.recipecart.storage.EntitySaver;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class GetRecipeCommandTest extends SimpleGetCommandTest<Recipe> {
     @Override
-    protected void addEntityToStorage(Recipe entity, EntitySaver saver) {
-        saver.updateRecipes(Collections.singletonList(entity));
+    protected void addEntitiesToStorage(Collection<Recipe> entities, EntitySaver saver) {
+        saver.updateRecipes(entities);
     }
 
     @Override

--- a/src/test/java/com/recipecart/usecases/GetRecipeCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetRecipeCommandTest.java
@@ -1,0 +1,41 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
+import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
+
+import com.recipecart.entities.Recipe;
+import com.recipecart.storage.EntitySaver;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class GetRecipeCommandTest extends SimpleGetCommandTest<Recipe> {
+    @Override
+    protected void addEntityToStorage(Recipe entity, EntitySaver saver) {
+        saver.updateRecipes(Collections.singletonList(entity));
+    }
+
+    @Override
+    protected SimpleGetCommand<Recipe> getGetEntityCommand(String name) {
+        return new GetRecipeCommand(name);
+    }
+
+    @Override
+    protected Stream<Arguments> getEntity() {
+        return TestUtils.generateArguments(TestData::getRecipes);
+    }
+
+    @Override
+    protected Stream<Arguments> getStorageWithEntity() {
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(), Collections.singletonList(TestData::getRecipes));
+    }
+
+    @Override
+    protected String getName(Recipe entity) {
+        return entity.getName();
+    }
+}

--- a/src/test/java/com/recipecart/usecases/GetTagCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetTagCommandTest.java
@@ -1,0 +1,41 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
+import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
+
+import com.recipecart.entities.Tag;
+import com.recipecart.storage.EntitySaver;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class GetTagCommandTest extends SimpleGetCommandTest<Tag> {
+    @Override
+    protected void addEntityToStorage(Tag entity, EntitySaver saver) {
+        saver.updateTags(Collections.singletonList(entity));
+    }
+
+    @Override
+    protected SimpleGetCommand<Tag> getGetEntityCommand(String name) {
+        return new GetTagCommand(name);
+    }
+
+    @Override
+    protected Stream<Arguments> getEntity() {
+        return TestUtils.generateArguments(TestData::getTags);
+    }
+
+    @Override
+    protected Stream<Arguments> getStorageWithEntity() {
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(), Collections.singletonList(TestData::getTags));
+    }
+
+    @Override
+    protected String getName(Tag entity) {
+        return entity.getName();
+    }
+}

--- a/src/test/java/com/recipecart/usecases/GetTagCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetTagCommandTest.java
@@ -8,14 +8,15 @@ import com.recipecart.entities.Tag;
 import com.recipecart.storage.EntitySaver;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class GetTagCommandTest extends SimpleGetCommandTest<Tag> {
     @Override
-    protected void addEntityToStorage(Tag entity, EntitySaver saver) {
-        saver.updateTags(Collections.singletonList(entity));
+    protected void addEntitiesToStorage(Collection<Tag> entities, EntitySaver saver) {
+        saver.updateTags(entities);
     }
 
     @Override

--- a/src/test/java/com/recipecart/usecases/GetUserCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetUserCommandTest.java
@@ -8,14 +8,15 @@ import com.recipecart.entities.User;
 import com.recipecart.storage.EntitySaver;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class GetUserCommandTest extends SimpleGetCommandTest<User> {
     @Override
-    protected void addEntityToStorage(User entity, EntitySaver saver) {
-        saver.updateUsers(Collections.singletonList(entity));
+    protected void addEntitiesToStorage(Collection<User> entities, EntitySaver saver) {
+        saver.updateUsers(entities);
     }
 
     @Override

--- a/src/test/java/com/recipecart/usecases/GetUserCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/GetUserCommandTest.java
@@ -1,0 +1,41 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.testutil.TestUtils.generateArgumentsCombos;
+import static com.recipecart.testutil.TestUtils.getMockStorageArrayGenerators;
+
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntitySaver;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class GetUserCommandTest extends SimpleGetCommandTest<User> {
+    @Override
+    protected void addEntityToStorage(User entity, EntitySaver saver) {
+        saver.updateUsers(Collections.singletonList(entity));
+    }
+
+    @Override
+    protected SimpleGetCommand<User> getGetEntityCommand(String name) {
+        return new GetUserCommand(name);
+    }
+
+    @Override
+    protected Stream<Arguments> getEntity() {
+        return TestUtils.generateArguments(TestData::getUsers);
+    }
+
+    @Override
+    protected Stream<Arguments> getStorageWithEntity() {
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(), Collections.singletonList(TestData::getUsers));
+    }
+
+    @Override
+    protected String getName(User entity) {
+        return entity.getUsername();
+    }
+}

--- a/src/test/java/com/recipecart/usecases/SearchRecipesCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/SearchRecipesCommandTest.java
@@ -11,6 +11,7 @@ import com.recipecart.entities.Recipe;
 import com.recipecart.storage.EntityStorage;
 import com.recipecart.testutil.TestData;
 import com.recipecart.testutil.TestUtils;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,8 +32,9 @@ public class SearchRecipesCommandTest {
     }
 
     private static Stream<Arguments> getInvalidTokensParams() {
-        return generateArgumentsWithStorage(
-                getMockStorageArrayGenerators(), TestData::getInvalidSearchTermSet);
+        return generateArgumentsCombos(
+                getMockStorageArrayGenerators(),
+                Collections.singletonList(TestData::getInvalidSearchTermSet));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/recipecart/usecases/ShoppingListCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/ShoppingListCommandTest.java
@@ -1,0 +1,59 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.entities.User;
+import com.recipecart.storage.EntityStorage;
+import com.recipecart.testutil.TestData;
+import com.recipecart.testutil.TestUtils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class ShoppingListCommandTest<T extends ShoppingListCommand> {
+    private EntityStorage storage;
+
+    @BeforeEach
+    void initStorage() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        storage = new EntityStorage(saveAndLoader, saveAndLoader);
+    }
+
+    protected static Stream<Arguments> getUser() {
+        return TestUtils.generateArguments(TestData::getUsers);
+    }
+
+    protected EntityStorage getStorage() {
+        return storage;
+    }
+
+    protected static <T extends ShoppingListCommand> void assertSuccessfulExecution(
+            T command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertTrue(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+        assertNotNull(command.getResultShoppingList());
+    }
+
+    protected static <T extends ShoppingListCommand> void assertUnsuccessfulExecution(
+            T command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertFalse(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+        assertNull(command.getResultShoppingList());
+    }
+
+    protected void assertShoppingListGood(T command) throws IOException {
+        User shopper =
+                getStorage()
+                        .getLoader()
+                        .getUsersByNames(Collections.singletonList(command.getShopperUsername()))
+                        .get(0);
+        assertEquals(command.getResultShoppingList(), shopper.getShoppingList());
+    }
+}

--- a/src/test/java/com/recipecart/usecases/ShoppingListCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/ShoppingListCommandTest.java
@@ -4,7 +4,7 @@ package com.recipecart.usecases;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.entities.User;
 import com.recipecart.storage.EntityStorage;
 import com.recipecart.testutil.TestData;
@@ -20,7 +20,7 @@ public class ShoppingListCommandTest<T extends ShoppingListCommand> {
 
     @BeforeEach
     void initStorage() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         storage = new EntityStorage(saveAndLoader, saveAndLoader);
     }
 

--- a/src/test/java/com/recipecart/usecases/SimpleCreateEntityCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/SimpleCreateEntityCommandTest.java
@@ -1,0 +1,140 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.usecases.Command.NOT_OK_ERROR;
+import static com.recipecart.usecases.EntityCommand.NOT_OK_BAD_STORAGE;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.storage.EntitySaver;
+import com.recipecart.storage.EntityStorage;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class SimpleCreateEntityCommandTest<T> {
+    private SimpleCreateEntityCommand<T> getAndExecuteCommand(T entity, EntityStorage storage) {
+        SimpleCreateEntityCommand<T> command = getCreateEntityCommand(entity);
+        command.setStorageSource(storage);
+        command.execute();
+
+        return command;
+    }
+
+    private static <T> void assertUnsuccessfulExecution(
+            SimpleCreateEntityCommand<T> command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertFalse(command.isSuccessful());
+        assertNull(command.getCreatedEntity());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    private static <T> void assertSuccessfulExecution(
+            SimpleCreateEntityCommand<T> command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertTrue(command.isSuccessful());
+        assertEquals(message, command.getExecutionMessage());
+        assertNotNull(command.getCreatedEntity());
+    }
+
+    protected void assertGoodEntity(T baseEntity, T outputEntity) {
+        assertEquals(baseEntity, outputEntity);
+    }
+
+    protected abstract Stream<Arguments> getEntity();
+
+    protected abstract Stream<Arguments> getStorageWithEntity();
+
+    protected abstract SimpleCreateEntityCommand<T> getCreateEntityCommand(T entity);
+
+    protected abstract T renameToNullEntity(T entity);
+
+    protected abstract void addEntitiesToStorage(Collection<T> entities, EntitySaver saver);
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testState(T toAdd) {
+        SimpleCreateEntityCommand<T> command = getCreateEntityCommand(toAdd);
+
+        assertGoodEntity(toAdd, command.getEntityToAdd());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testGetCreatedEntityBeforeExecution(T toAdd) {
+        SimpleCreateEntityCommand<T> command = getCreateEntityCommand(toAdd);
+
+        assertThrows(IllegalStateException.class, command::getCreatedEntity);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testCreateEntity(EntityStorage storage, T toAdd) {
+        SimpleCreateEntityCommand<T> command = getAndExecuteCommand(toAdd, storage);
+
+        assertSuccessfulExecution(command, command.getOkEntityCreatedMessage());
+        assertGoodEntity(toAdd, command.getCreatedEntity());
+    }
+
+    @Test
+    void testNullEntity() {
+        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        SimpleCreateEntityCommand<T> command =
+                getAndExecuteCommand(null, new EntityStorage(saveAndLoader, saveAndLoader));
+
+        assertUnsuccessfulExecution(command, command.getNotOkInvalidEntityMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testInvalidEntity(EntityStorage storage, T toAdd) {
+        T invalidEntity = renameToNullEntity(toAdd);
+        SimpleCreateEntityCommand<T> command = getAndExecuteCommand(invalidEntity, storage);
+
+        assertUnsuccessfulExecution(command, command.getNotOkInvalidEntityMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testEntityNameTaken(EntityStorage storage, T toAdd) {
+        addEntitiesToStorage(Collections.singleton(toAdd), storage.getSaver());
+        SimpleCreateEntityCommand<T> command = getAndExecuteCommand(toAdd, storage);
+
+        assertUnsuccessfulExecution(command, command.getNotOkEntityNameAlreadyTakenMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testNullStorageSource(T toAdd) {
+        SimpleCreateEntityCommand<T> command = getCreateEntityCommand(toAdd);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testCreateEntityWithError(T toAdd) {
+        SimpleCreateEntityCommand<T> command = getCreateEntityCommand(toAdd);
+        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testExceptionsAfterEntityCreation(EntityStorage storage, T toAdd) {
+        SimpleCreateEntityCommand<T> command = getAndExecuteCommand(toAdd, storage);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/usecases/SimpleCreateEntityCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/SimpleCreateEntityCommandTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.recipecart.database.BadEntityLoader;
 import com.recipecart.database.BadEntitySaver;
-import com.recipecart.database.MockEntitySaveAndLoader;
+import com.recipecart.database.MapEntitySaveAndLoader;
 import com.recipecart.storage.EntitySaver;
 import com.recipecart.storage.EntityStorage;
 import java.util.Collection;
@@ -86,7 +86,7 @@ public abstract class SimpleCreateEntityCommandTest<T> {
 
     @Test
     void testNullEntity() {
-        MockEntitySaveAndLoader saveAndLoader = new MockEntitySaveAndLoader();
+        MapEntitySaveAndLoader saveAndLoader = new MapEntitySaveAndLoader();
         SimpleCreateEntityCommand<T> command =
                 getAndExecuteCommand(null, new EntityStorage(saveAndLoader, saveAndLoader));
 

--- a/src/test/java/com/recipecart/usecases/SimpleGetCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/SimpleGetCommandTest.java
@@ -9,6 +9,8 @@ import com.recipecart.database.BadEntityLoader;
 import com.recipecart.database.BadEntitySaver;
 import com.recipecart.storage.EntitySaver;
 import com.recipecart.storage.EntityStorage;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,7 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public abstract class SimpleGetCommandTest<T> {
     private SimpleGetCommand<T> getAndExecuteCommand(T entity, EntityStorage storage) {
         SimpleGetCommand<T> command = getGetEntityCommand(getName(entity));
-        addEntityToStorage(entity, storage.getSaver());
+        addEntitiesToStorage(Collections.singleton(entity), storage.getSaver());
         command.setStorageSource(storage);
         command.execute();
 
@@ -41,7 +43,7 @@ public abstract class SimpleGetCommandTest<T> {
         assertEquals(message, command.getExecutionMessage());
     }
 
-    protected abstract void addEntityToStorage(T entity, EntitySaver saver);
+    protected abstract void addEntitiesToStorage(Collection<T> entity, EntitySaver saver);
 
     protected abstract SimpleGetCommand<T> getGetEntityCommand(String name);
 
@@ -90,7 +92,7 @@ public abstract class SimpleGetCommandTest<T> {
     @MethodSource("getStorageWithEntity")
     void testNullName(EntityStorage storage, T entity) {
         SimpleGetCommand<T> command = getGetEntityCommand(null);
-        addEntityToStorage(entity, storage.getSaver());
+        addEntitiesToStorage(Collections.singleton(entity), storage.getSaver());
         command.setStorageSource(storage);
         command.execute();
 

--- a/src/test/java/com/recipecart/usecases/SimpleGetCommandTest.java
+++ b/src/test/java/com/recipecart/usecases/SimpleGetCommandTest.java
@@ -1,0 +1,126 @@
+/* (C)2023 */
+package com.recipecart.usecases;
+
+import static com.recipecart.usecases.Command.NOT_OK_ERROR;
+import static com.recipecart.usecases.EntityCommand.NOT_OK_BAD_STORAGE;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.recipecart.database.BadEntityLoader;
+import com.recipecart.database.BadEntitySaver;
+import com.recipecart.storage.EntitySaver;
+import com.recipecart.storage.EntityStorage;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class SimpleGetCommandTest<T> {
+    private SimpleGetCommand<T> getAndExecuteCommand(T entity, EntityStorage storage) {
+        SimpleGetCommand<T> command = getGetEntityCommand(getName(entity));
+        addEntityToStorage(entity, storage.getSaver());
+        command.setStorageSource(storage);
+        command.execute();
+
+        return command;
+    }
+
+    private static <T> void assertUnsuccessfulExecution(
+            SimpleGetCommand<T> command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertFalse(command.isSuccessful());
+        assertNull(command.getRetrievedEntity());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    private static <T> void assertSuccessfulExecution(SimpleGetCommand<T> command, String message) {
+        assertTrue(command.isFinishedExecuting());
+        assertTrue(command.isSuccessful());
+        assertNotNull(command.getRetrievedEntity());
+        assertEquals(message, command.getExecutionMessage());
+    }
+
+    protected abstract void addEntityToStorage(T entity, EntitySaver saver);
+
+    protected abstract SimpleGetCommand<T> getGetEntityCommand(String name);
+
+    protected abstract Stream<Arguments> getEntity();
+
+    protected abstract Stream<Arguments> getStorageWithEntity();
+
+    protected abstract String getName(T entity);
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testState(T entity) {
+        SimpleGetCommand<T> command = getGetEntityCommand(getName(entity));
+
+        assertEquals(getName(entity), command.getEntityName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testGetRetrievedEntityBeforeExecution(T entity) {
+        SimpleGetCommand<T> command = getGetEntityCommand(getName(entity));
+
+        assertThrows(IllegalStateException.class, command::getRetrievedEntity);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testRetrieveEntity(EntityStorage storage, T entity) {
+        SimpleGetCommand<T> command = getAndExecuteCommand(entity, storage);
+
+        assertSuccessfulExecution(command, command.getOkEntityRetrievedMessage());
+        assertEquals(entity, command.getRetrievedEntity());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testEntityNotFound(EntityStorage storage, T entity) {
+        SimpleGetCommand<T> command = getGetEntityCommand(getName(entity));
+        command.setStorageSource(storage);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, command.getNotOkNotFoundMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testNullName(EntityStorage storage, T entity) {
+        SimpleGetCommand<T> command = getGetEntityCommand(null);
+        addEntityToStorage(entity, storage.getSaver());
+        command.setStorageSource(storage);
+        command.execute();
+
+        assertUnsuccessfulExecution(command, command.getNotOkNotFoundMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testNullStorageSource(T entity) {
+        SimpleGetCommand<T> command = getGetEntityCommand(getName(entity));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_BAD_STORAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEntity")
+    void testRetrievalWithError(T entity) {
+        SimpleGetCommand<T> command = getGetEntityCommand(getName(entity));
+        command.setStorageSource(new EntityStorage(new BadEntitySaver(), new BadEntityLoader()));
+        command.execute();
+
+        assertUnsuccessfulExecution(command, NOT_OK_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStorageWithEntity")
+    void testExceptionsAfterRetrieval(EntityStorage storage, T entity) {
+        SimpleGetCommand<T> command = getAndExecuteCommand(entity, storage);
+
+        assertThrows(IllegalStateException.class, command::execute);
+    }
+}

--- a/src/test/java/com/recipecart/utils/UtilsTest.java
+++ b/src/test/java/com/recipecart/utils/UtilsTest.java
@@ -1,0 +1,33 @@
+/* (C)2023 */
+package com.recipecart.utils;
+
+import static com.recipecart.utils.Utils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class UtilsTest {
+    private static Stream<Arguments> getMapSum() {
+        return Stream.of(
+                Arguments.of(Map.of("a", 1.0), Map.of("b", 2.0), Map.of("a", 1.0, "b", 2.0)),
+                Arguments.of(
+                        Map.of("a", 1.0, "b", 2.0),
+                        Map.of("b", 3.0, "c", 4.0),
+                        Map.of("a", 1.0, "b", 5.0, "c", 4.0)),
+                Arguments.of(
+                        Map.of("1", 10.0, "2", 20.0),
+                        Map.of("1", 30.0, "2", 40.0),
+                        Map.of("1", 40.0, "2", 60.0)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMapSum")
+    void testAddMaps(
+            Map<Object, Double> map1, Map<Object, Double> map2, Map<Object, Double> expected) {
+        assertEquals(expected, addMaps(map1, map2));
+    }
+}


### PR DESCRIPTION
Designed more API routes, in the api_routes.md file. There are 12 total.
- 4 of these API routes are to create a Recipe/User/Ingredient/Tag and save it to the data access layer
- 4 of these API routes are to get a known Recipe/User/Ingredient/Tag by (user)name
- The remaining 4 cover the 4 remaining use cases in the Requirements doc (since "Create Recipe" is already one).

All 12 API routes are now implemented. As of the current edit of this comment, though, the handling of the HTTP requests for the API routes have not gotten automated testing.

In terms of API route implementation, this pull request also created, tested, and implemented various classes in the "usecases" package, each corresponding to handling an API route:
- CreateTagCommand: "Create tag"
- CreateIngredientCommand: "Create ingredient"
- CreateUserCommand: "Create user"
- CreateRecipeCommand (already implemented before this PR): "Create recipe"
- GetTagCommand: "Get tag"
- GetIngredientCommand: "Get ingredient"
- GetUserCommand: "Get user"
- GetRecipeCommand: "Get recipe"
- SearchRecipeCommand (already implemented before this PR): "Search for recipe"
- BookmarkRecipeCommand: "Bookmark recipe:
- AddIngredientsToShoppingListCommand: "Add ingredients to shopping list"
- AddRecipeToShoppingListCommand: "Add recipe ingredients to shopping list"

Also, the user authentication for the routes that require it has not been implemented yet. So, those routes currently don't require any user authentication.